### PR TITLE
Gesture handler requires correction on android

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,6 +2,8 @@ import { NavigationContainer } from '@react-navigation/native';
 import React, { useEffect } from 'react';
 import * as SplashScreen from 'expo-splash-screen';
 import RegistrationStackNavigator from './navigation/Registration/RegistrationStackNavigator';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import styles from './styles';
 import {
   useFonts,
   JetBrainsMono_100Thin_Italic,
@@ -31,10 +33,13 @@ export default function App() {
   }, [fontsLoaded]);
 
   return (
-    <NavigationContainer>
-      <SafeAreaProvider>
-        <RegistrationStackNavigator/>
-      </SafeAreaProvider>
-    </NavigationContainer>
+    <GestureHandlerRootView style={styles.gestureHandler}>
+      <NavigationContainer>
+        <SafeAreaProvider>
+          <RegistrationStackNavigator/>
+        </SafeAreaProvider>
+      </NavigationContainer>
+    </GestureHandlerRootView>
+    
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "firebase": "^10.9.0",
         "react": "18.2.0",
         "react-native": "0.73.4",
+        "react-native-gesture-handler": "~2.14.0",
         "react-native-keyboard-aware-scroll-view": "0.9.5",
         "react-native-safe-area-context": "4.9.0",
         "react-native-screens": "~3.29.0",
@@ -3144,7 +3145,6 @@
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
       "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
-      "peer": true,
       "dependencies": {
         "@types/hammerjs": "^2.0.36"
       },
@@ -8009,8 +8009,7 @@
     "node_modules/@types/hammerjs": {
       "version": "2.0.45",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.45.tgz",
-      "integrity": "sha512-qkcUlZmX6c4J8q45taBKTL3p+LbITgyx7qhlPYOdOHZB7B31K0mXbP5YA7i7SgDeEGuI9MnumiKPEMrxg8j3KQ==",
-      "peer": true
+      "integrity": "sha512-qkcUlZmX6c4J8q45taBKTL3p+LbITgyx7qhlPYOdOHZB7B31K0mXbP5YA7i7SgDeEGuI9MnumiKPEMrxg8j3KQ=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -12100,7 +12099,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -12108,8 +12106,7 @@
     "node_modules/hoist-non-react-statics/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "peer": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hosted-git-info": {
       "version": "3.0.8",
@@ -15991,10 +15988,9 @@
       }
     },
     "node_modules/react-native-gesture-handler": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.16.0.tgz",
-      "integrity": "sha512-1hFkx7RIfeJSyTQQ0Nkv4icFVZ5+XjQkd47OgZMBFzoB7ecL+nFSz8KLi3OCWOhq+nbHpSPlSG5VF3CQNCJpWA==",
-      "peer": true,
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.14.1.tgz",
+      "integrity": "sha512-YiM1BApV4aKeuwsM6O4C2ufwewYEKk6VMXOt0YqEZFMwABBFWhXLySFZYjBSNRU2USGppJbfHP1q1DfFQpKhdA==",
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-native-svg": "^15.1.0",
     "react-native-keyboard-aware-scroll-view": "0.9.5",
     "react-native-safe-area-context": "4.9.0",
-    "react-native-web": "~0.19.6"
+    "react-native-web": "~0.19.6",
+    "react-native-gesture-handler": "~2.14.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/styles.ts
+++ b/styles.ts
@@ -1,0 +1,9 @@
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+    gestureHandler: {
+        flex: 1,
+    }
+});
+
+export default styles;


### PR DESCRIPTION
### What I did
Fixed an error when launching the app on an

![WhatsApp Image 2024-04-10 at 00 17 01_1ffc76dd](https://github.com/uniconnect-epfl/uniconnect/assets/93329823/a0f50f83-e025-42b6-804c-6148495a6a1c)

### How I did it

I had to add the dependency `"react-native-gesture-handler": "~2.14.0"`.
However, when I first added a previous version of the dependency (the "1.10.3") and this got me another error:

![WhatsApp Image 2024-04-10 at 00 17 01_22f80436](https://github.com/uniconnect-epfl/uniconnect/assets/93329823/32cc1df8-8128-48da-b6d9-344ebcf36571)

Upgrading the dependency to version 2.14.0 got rid of the error.

I then also wrapped the app into a GestureHandlerRootView as recommended [here](https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation/). However this didn't fix the issue, the actual fix was to add the dependency and import it, I tried with and without the GestureHandlerRootView. I kept it because it seemed good practice for our application configuration.

### Result

The app works now normally on my android device

### Note 

- Please don't forget to test the app on IOS during review.
- Because it helped me with my problem I think we should address the warnings when we'll have the time:

<img width="564" alt="warnings" src="https://github.com/uniconnect-epfl/uniconnect/assets/93329823/52439745-4cf1-414b-848c-79602a3cd5b4">
