### PR TITLE
Profile screens components

### DIFF
--- a/__test__/components/ExpandableDescription/ExpandableDescription.test.tsx
+++ b/__test__/components/ExpandableDescription/ExpandableDescription.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react-native'
+import ExpandableDescription from '../../../components/ExpandableDescription/ExpandableDescription'
+import { TouchableOpacity } from 'react-native'
+
+describe('ExpandableDescription', () => {
+  
+  it('renders the screen', () => {
+    const component = render(
+        <ExpandableDescription
+            description='salue'
+        />
+    )
+    expect(component).toBeTruthy()
+  })
+
+  it('renders correct text', () => {
+    const description = "hfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vo"
+    const { getByText } = render(
+        <ExpandableDescription
+            description={description}
+        />
+    )
+    expect(getByText(description)).toBeTruthy()
+  })
+
+  it('renders long text only when expanding', () => {
+    const description = "hfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vo "
+    const { UNSAFE_getByType, getByText } = render(
+        <ExpandableDescription
+            description={description}
+        />
+    )
+    expect(getByText(description).props.numberOfLines).toBe(4)
+    fireEvent.press(UNSAFE_getByType(TouchableOpacity))
+    expect(getByText(description).props.numberOfLines).toBeFalsy()
+  })
+  
+})

--- a/__test__/components/ExpandableDescription/ExpandableDescription.test.tsx
+++ b/__test__/components/ExpandableDescription/ExpandableDescription.test.tsx
@@ -15,7 +15,7 @@ describe('ExpandableDescription', () => {
   })
 
   it('renders correct text', () => {
-    const description = "hfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vo"
+    const description = 'hfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vo'
     const { getByText } = render(
         <ExpandableDescription
             description={description}
@@ -25,7 +25,7 @@ describe('ExpandableDescription', () => {
   })
 
   it('renders long text only when expanding', () => {
-    const description = "hfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vo "
+    const description = 'hfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vohfjdklahfjd fhei lv hsnrei vruie vei veiu eul nesbua bfwzuag fwua feuo vo '
     const { UNSAFE_getByType, getByText } = render(
         <ExpandableDescription
             description={description}

--- a/__test__/components/GeneralProfile/GeneralProfile.test.tsx
+++ b/__test__/components/GeneralProfile/GeneralProfile.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import GeneralProfile from '../../../components/GeneralProfile/GeneralProfile'
+
+describe('GeneralProfile', () => {
+  
+  it('renders the screen', () => {
+    const component = render(
+        <GeneralProfile 
+            name="name"
+            surname="surname"
+            location="EPFL"
+        />
+    )
+    expect(component).toBeTruthy()
+  })
+
+  it('renders right informations', () => {
+    const name = "naajeh ceai nncueia of v "
+    const surname = "jdvalgn jre fher verh vndjk nvdsk b"
+    const location = "vjksldgb reber erj bvhjd bjks nclnewa"
+
+    const { queryByText, getByText } = render(
+        <GeneralProfile 
+            name={name}
+            surname={surname}
+            location={location}
+        />
+    )
+    expect(getByText(name + " " + surname)).toBeTruthy()
+    expect(getByText(location)).toBeTruthy()
+    expect(queryByText("name")).toBeFalsy()
+  })
+  
+})

--- a/__test__/components/GeneralProfile/GeneralProfile.test.tsx
+++ b/__test__/components/GeneralProfile/GeneralProfile.test.tsx
@@ -7,18 +7,18 @@ describe('GeneralProfile', () => {
   it('renders the screen', () => {
     const component = render(
         <GeneralProfile 
-            name="name"
-            surname="surname"
-            location="EPFL"
+            name='name'
+            surname='surname'
+            location='EPFL'
         />
     )
     expect(component).toBeTruthy()
   })
 
   it('renders right informations', () => {
-    const name = "naajeh ceai nncueia of v "
-    const surname = "jdvalgn jre fher verh vndjk nvdsk b"
-    const location = "vjksldgb reber erj bvhjd bjks nclnewa"
+    const name = 'naajeh ceai nncueia of v '
+    const surname = 'jdvalgn jre fher verh vndjk nvdsk b'
+    const location = 'vjksldgb reber erj bvhjd bjks nclnewa'
 
     const { queryByText, getByText } = render(
         <GeneralProfile 
@@ -27,9 +27,9 @@ describe('GeneralProfile', () => {
             location={location}
         />
     )
-    expect(getByText(name + " " + surname)).toBeTruthy()
+    expect(getByText(name + ' ' + surname)).toBeTruthy()
     expect(getByText(location)).toBeTruthy()
-    expect(queryByText("name")).toBeFalsy()
+    expect(queryByText('name')).toBeFalsy()
   })
   
 })

--- a/components/ExpandableDescription/ExpandableDescription.tsx
+++ b/components/ExpandableDescription/ExpandableDescription.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { View, Text, TouchableOpacity } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { black } from '../../assets/colors/colors'
-import { styles } from "./styles"
+import { styles } from './styles'
 
 interface ExpandableDescriptionProps {
   description: string;
@@ -22,7 +22,7 @@ const ExpandableDescription: React.FC<ExpandableDescriptionProps> = ({ descripti
       <TouchableOpacity 
         style={styles.button}
         onPress={() => setLimitNbLines(!limitNbLines) }>
-          <Ionicons name={limitNbLines ? "chevron-down-outline" : "chevron-up-outline"} size={24} color={black} />
+          <Ionicons name={limitNbLines ? 'chevron-down-outline' : 'chevron-up-outline'} size={24} color={black} />
       </TouchableOpacity>
     </View>
   )

--- a/components/ExpandableDescription/ExpandableDescription.tsx
+++ b/components/ExpandableDescription/ExpandableDescription.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react'
+import { View, Text, TouchableOpacity } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { black } from '../../assets/colors/colors'
+import { styles } from "./styles"
+
+interface ExpandableDescriptionProps {
+  description: string;
+}
+
+const ExpandableDescription: React.FC<ExpandableDescriptionProps> = ({ description }) => {
+  const initialNbLines = 4
+  const [limitNbLines, setLimitNbLines] = useState(true)
+
+  return (
+    <View>
+      <Text 
+          style={styles.text}
+          numberOfLines={limitNbLines ? initialNbLines : undefined}>
+          {description}
+        </Text>
+      <TouchableOpacity 
+        style={styles.button}
+        onPress={() => setLimitNbLines(!limitNbLines) }>
+          <Ionicons name={limitNbLines ? "chevron-down-outline" : "chevron-up-outline"} size={24} color={black} />
+      </TouchableOpacity>
+    </View>
+  )
+}
+
+export default ExpandableDescription

--- a/components/ExpandableDescription/styles.ts
+++ b/components/ExpandableDescription/styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from "react-native"
+import { StyleSheet } from 'react-native'
 
 export const styles = StyleSheet.create({
     button:{
-        alignItems: "center"
+        alignItems: 'center'
     },
     text:{
         fontSize: 12,

--- a/components/ExpandableDescription/styles.ts
+++ b/components/ExpandableDescription/styles.ts
@@ -1,0 +1,11 @@
+import { StyleSheet } from "react-native"
+
+export const styles = StyleSheet.create({
+    button:{
+        alignItems: "center"
+    },
+    text:{
+        fontSize: 12,
+        paddingHorizontal: 10,
+    },
+})

--- a/components/GeneralProfile/GeneralProfile.tsx
+++ b/components/GeneralProfile/GeneralProfile.tsx
@@ -15,7 +15,7 @@ const GeneralProfile: React.FC<GeneralProfileProps> = ({
     surname,
     location
 }) => {
-  const profilePictureUrl = ""
+  const profilePictureUrl = ''
 
   return (
     <View style={styles.container}>
@@ -27,14 +27,14 @@ const GeneralProfile: React.FC<GeneralProfileProps> = ({
             />
         ) : (
             <View style={styles.profilePicture}>
-                <Ionicons name="person" size={50} color={black} />
+                <Ionicons name='person' size={50} color={black} />
             </View>
         )}
 
         <Text style={styles.name}>{name} {surname}</Text>
 
         <View style={styles.horizontalContainer}>
-            <Ionicons name="location-outline" size={14} color={black} />
+            <Ionicons name='location-outline' size={14} color={black} />
             <Text style={styles.location}>{location}</Text>
         </View>
 

--- a/components/GeneralProfile/GeneralProfile.tsx
+++ b/components/GeneralProfile/GeneralProfile.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { View, Image, Text } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { styles } from './styles'
+import { black } from '../../assets/colors/colors'
+
+interface GeneralProfileProps {
+    name: string,
+    surname: string,
+    location: string
+}
+
+const GeneralProfile: React.FC<GeneralProfileProps> = ({ 
+    name,
+    surname,
+    location
+}) => {
+  const profilePictureUrl = ""
+
+  return (
+    <View style={styles.container}>
+
+        {profilePictureUrl ? (
+            <Image
+                style={styles.profilePicture}
+                source={{ uri: profilePictureUrl }}
+            />
+        ) : (
+            <View style={styles.profilePicture}>
+                <Ionicons name="person" size={50} color={black} />
+            </View>
+        )}
+
+        <Text style={styles.name}>{name} {surname}</Text>
+
+        <View style={styles.horizontalContainer}>
+            <Ionicons name="location-outline" size={14} color={black} />
+            <Text style={styles.location}>{location}</Text>
+        </View>
+
+    </View>
+  )
+}
+
+export default GeneralProfile

--- a/components/GeneralProfile/styles.ts
+++ b/components/GeneralProfile/styles.ts
@@ -1,0 +1,30 @@
+import { StyleSheet } from "react-native"
+import { peach } from "../../assets/colors/colors"
+
+export const styles = StyleSheet.create({
+    container: {
+        justifyContent: 'center',
+        left: 10,
+        margin: 10,
+    },
+    horizontalContainer: {
+        flexDirection: "row"
+    },
+    location: {
+        fontSize: 11,
+    },
+    name: {
+        fontSize: 16,
+        fontWeight: 'bold',
+        marginVertical: 5,
+    },
+    profilePicture: {
+        alignItems: 'center',
+        backgroundColor: peach,
+        borderRadius: 40, // to make it circular
+        height: 80,
+        justifyContent: 'center',
+        width: 80,
+    },
+
+})

--- a/components/GeneralProfile/styles.ts
+++ b/components/GeneralProfile/styles.ts
@@ -1,5 +1,5 @@
-import { StyleSheet } from "react-native"
-import { peach } from "../../assets/colors/colors"
+import { StyleSheet } from 'react-native'
+import { peach } from '../../assets/colors/colors'
 
 export const styles = StyleSheet.create({
     container: {
@@ -8,7 +8,7 @@ export const styles = StyleSheet.create({
         margin: 10,
     },
     horizontalContainer: {
-        flexDirection: "row"
+        flexDirection: 'row'
     },
     location: {
         fontSize: 11,

--- a/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
+++ b/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
@@ -1,7 +1,7 @@
-import { View } from "react-native"
-import { styles } from "./styles"
-import ExpandableDescription from "../../../components/ExpandableDescription/ExpandableDescription"
-import GeneralProfile from "../../../components/GeneralProfile/GeneralProfile"
+import { View } from 'react-native'
+import { styles } from './styles'
+import ExpandableDescription from '../../../components/ExpandableDescription/ExpandableDescription'
+import GeneralProfile from '../../../components/GeneralProfile/GeneralProfile'
 
 export const MyProfileScreen = () => {
   return (
@@ -9,14 +9,14 @@ export const MyProfileScreen = () => {
 
       <View style={styles.leftAlign}>
         <GeneralProfile
-          name={"Name"}
-          surname={"Surname"}
-          location={"le Mont-sur-Lausanne"}
+          name={'Name'}
+          surname={'Surname'}
+          location={'le Mont-sur-Lausanne'}
         />
       </View>
 
       <ExpandableDescription
-        description={"slajfeiohadslh oh ho sdhv lsvnjls bvdfjl vj shdls hvueri hvueos hvurei shvureio vhruieo vhuris hviuds vnfjd re vuirep uir hfeuiphgfure fhueir hguriewp hfurie hfruie hfuire hfure uire uier huirs hui bhuero vureso huire hure hzureepseo guers hvuip vuip hurieps hurips hvurips bhutrid bhurtipd hbuips hurieps huiers vhurieps vuries hvureips hureis bfhres fures huirpe burip vuirso hvzureo gfuersh guirp hutirp hveruips vuresp hv"}
+        description={'slajfeiohadslh oh ho sdhv lsvnjls bvdfjl vj shdls hvueri hvueos hvurei shvureio vhruieo vhuris hviuds vnfjd re vuirep uir hfeuiphgfure fhueir hguriewp hfurie hfruie hfuire hfure uire uier huirs hui bhuero vureso huire hure hzureepseo guers hvuip vuip hurieps hurips hvurips bhutrid bhurtipd hbuips hurieps huiers vhurieps vuries hvureips hureis bfhres fures huirpe burip vuirso hvzureo gfuersh guirp hutirp hveruips vuresp hv'}
       />
 
     </View>

--- a/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
+++ b/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
@@ -1,11 +1,24 @@
-import { View, Text } from "react-native"
+import { View } from "react-native"
 import { styles } from "./styles"
-
+import ExpandableDescription from "../../../components/ExpandableDescription/ExpandableDescription"
+import GeneralProfile from "../../../components/GeneralProfile/GeneralProfile"
 
 export const MyProfileScreen = () => {
   return (
     <View style={styles.view}>
-      <Text>This is the MyProfile screen</Text>
+
+      <View style={styles.leftAlign}>
+        <GeneralProfile
+          name={"Name"}
+          surname={"Surname"}
+          location={"le Mont-sur-Lausanne"}
+        />
+      </View>
+
+      <ExpandableDescription
+        description={"slajfeiohadslh oh ho sdhv lsvnjls bvdfjl vj shdls hvueri hvueos hvurei shvureio vhruieo vhuris hviuds vnfjd re vuirep uir hfeuiphgfure fhueir hguriewp hfurie hfruie hfuire hfure uire uier huirs hui bhuero vureso huire hure hzureepseo guers hvuip vuip hurieps hurips hvurips bhutrid bhurtipd hbuips hurieps huiers vhurieps vuries hvureips hureis bfhres fures huirpe burip vuirso hvzureo gfuersh guirp hutirp hveruips vuresp hv"}
+      />
+
     </View>
   )
 }

--- a/screens/Profile/MyProfileScreen/styles.ts
+++ b/screens/Profile/MyProfileScreen/styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from "react-native"
+import { StyleSheet } from 'react-native'
 
 export const styles = StyleSheet.create({
   leftAlign: {
-    alignSelf: "flex-start"
+    alignSelf: 'flex-start'
   },
   view: {
     alignItems: 'center',

--- a/screens/Profile/MyProfileScreen/styles.ts
+++ b/screens/Profile/MyProfileScreen/styles.ts
@@ -1,9 +1,13 @@
 import { StyleSheet } from "react-native"
 
 export const styles = StyleSheet.create({
+  leftAlign: {
+    alignSelf: "flex-start"
+  },
   view: {
     alignItems: 'center',
     flex: 1,
     justifyContent: 'center'
-  }
+  },
+  
 })


### PR DESCRIPTION
# What I did
Added two components to render the basic of a profile and its description. These components will be used to make the profile screens later. The goal is to modularize them because the different profile screens will be very similar.

# How I did it
Defined two new components:
- ExpandableDescription
- GeneralProfile

Implemented them with react native components and made their unit tests in two new test files. I modified MyProfileScreen.tsx to display them for the moment. I didn't add any new dependency nor modified any other file.

# How to verify it
Launch the app and log in. You can see the two components displayed in the "my profile" screen (by clicking on the top left of the screen).

# Demo 

<img width="200" height="450" alt="Capture" src="https://github.com/uniconnect-epfl/uniconnect/assets/93329823/d5bdb034-c79e-418d-9481-62fbc83aaf2f">

<img width="200" height="450" alt="Capture" src="https://github.com/uniconnect-epfl/uniconnect/assets/93329823/d87a2980-f484-4bef-9804-68d862d45143">

# Pre-merge checklist
The changes I have introduced:
- [x] work correctly
- [x] do not break other functionalities
- [x] work correctly on Android
- [x] are fully tested