### PR TITLE
fix: exclude tests from coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,8 +3,8 @@ sonar.projectKey=uniconnect-epfl_uniconnect
 sonar.host.url=https://sonarcloud.io
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.sources=./
-sonar.test=__test__/
-sonar.coverage.exclusions=__test__/
+sonar.test=./__test__/
+sonar.exclusions=./__test__/
 
 # --- optional properties ---
 


### PR DESCRIPTION
# What I did
excluded tests folder from the Sonar coverage calculation.