### PR TITLE
feat: my profile screen

### DIFF
--- a/__test__/screens/Profile/MyProfileScreen/MyProfileScreen.test.tsx
+++ b/__test__/screens/Profile/MyProfileScreen/MyProfileScreen.test.tsx
@@ -1,12 +1,51 @@
-import React from 'react'
-import { render } from '@testing-library/react-native'
-import { MyProfileScreen } from '../../../../screens/Profile/MyProfileScreen/MyProfileScreen'
+import React from "react"
+import { render, fireEvent } from "@testing-library/react-native"
+import { MyProfileScreen } from "../../../../screens/Profile/MyProfileScreen/MyProfileScreen"
+import { useNavigation } from "@react-navigation/native"
 
-describe('MyProfileScreen', () => {
-  
-  it('renders the screen', () => {
-    const component = render(<MyProfileScreen />)
-    expect(component).toBeTruthy()
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: jest.fn(),
+}))
+
+jest.mock("../../../../components/GeneralProfile/GeneralProfile", () => "GeneralProfile")
+jest.mock("../../../../components/ExpandableDescription/ExpandableDescription", () => "ExpandableDescription")
+jest.mock("../../../../components/InputField/InputField", () => "InputField")
+jest.mock("@expo/vector-icons/Ionicons", () => "Ionicons")
+
+describe("MyProfileScreen", () => {
+  const navigateMock = jest.fn()
+
+  beforeEach(() => {
+    // Setup navigation mock
+    (useNavigation as jest.Mock).mockReturnValue({
+      navigate: navigateMock,
+    })
   })
-  
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders correctly", () => {
+    const { getByText } = render(<MyProfileScreen />)
+    
+    expect(getByText("Update")).toBeTruthy()
+    expect(getByText("QR")).toBeTruthy()
+  })
+
+  it("navigates to update profile when update button is pressed", () => {
+    const { getByText } = render(<MyProfileScreen />)
+    const updateButton = getByText("Update")
+    
+    fireEvent.press(updateButton)
+    expect(navigateMock).toHaveBeenCalledWith("Update my profile")
+  })
+
+  it("navigates to my QR code when QR button is pressed", () => {
+    const { getByText } = render(<MyProfileScreen />)
+    const qrButton = getByText("QR")
+    
+    fireEvent.press(qrButton)
+    expect(navigateMock).toHaveBeenCalledWith("My QR code")
+  })
 })

--- a/__test__/screens/Profile/MyProfileScreen/MyProfileScreen.test.tsx
+++ b/__test__/screens/Profile/MyProfileScreen/MyProfileScreen.test.tsx
@@ -38,7 +38,7 @@ describe("MyProfileScreen", () => {
     const updateButton = getByText("Update")
     
     fireEvent.press(updateButton)
-    expect(navigateMock).toHaveBeenCalledWith("Update my profile")
+    expect(navigateMock).toHaveBeenCalledWith("UpdateProfile")
   })
 
   it("navigates to my QR code when QR button is pressed", () => {
@@ -46,6 +46,6 @@ describe("MyProfileScreen", () => {
     const qrButton = getByText("QR")
     
     fireEvent.press(qrButton)
-    expect(navigateMock).toHaveBeenCalledWith("My QR code")
+    expect(navigateMock).toHaveBeenCalledWith("MyQR")
   })
 })

--- a/__test__/screens/Profile/MyQrCode/MyQrCodeScreen.test.tsx
+++ b/__test__/screens/Profile/MyQrCode/MyQrCodeScreen.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import { MyQrCodeScreen } from '../../../../screens/Profile/MyQrCode/MyQrCodeScreen'
+
+describe('MyQrCodeScreen', () => {
+  
+  it('renders correctly', () => {
+    const component = render(<MyQrCodeScreen />)
+    expect(component).toBeTruthy()
+  })
+  
+})

--- a/__test__/screens/Profile/UpdateMyProfile/UpdateMyProfileScreen.test.tsx
+++ b/__test__/screens/Profile/UpdateMyProfile/UpdateMyProfileScreen.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import { UpdateMyProfileScreen } from '../../../../screens/Profile/UpdateMyProfile/UpdateMyProfileScreen'
+
+describe('UpdateMyProfileScreen', () => {
+  
+  it('renders correctly', () => {
+    const component = render(<UpdateMyProfileScreen />)
+    expect(component).toBeTruthy()
+  })
+  
+})

--- a/components/ExpandableDescription/ExpandableDescription.tsx
+++ b/components/ExpandableDescription/ExpandableDescription.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react'
-import { View, Text, TouchableOpacity } from 'react-native'
-import { Ionicons } from '@expo/vector-icons'
-import { black } from '../../assets/colors/colors'
-import { styles } from './styles'
-import { globalStyles } from '../../assets/global/globalStyles'
+import React, { useState } from "react"
+import { View, Text, TouchableOpacity } from "react-native"
+import { Ionicons } from "@expo/vector-icons"
+import { black } from "../../assets/colors/colors"
+import { styles } from "./styles"
+import { globalStyles } from "../../assets/global/globalStyles"
 
 interface ExpandableDescriptionProps {
   description: string;
@@ -23,7 +23,7 @@ const ExpandableDescription: React.FC<ExpandableDescriptionProps> = ({ descripti
       <TouchableOpacity 
         style={styles.button}
         onPress={() => setLimitNbLines(!limitNbLines) }>
-          <Ionicons name={limitNbLines ? 'chevron-down-outline' : 'chevron-up-outline'} size={24} color={black} />
+          <Ionicons name={limitNbLines ? "chevron-down-outline" : "chevron-up-outline"} size={24} color={black} />
       </TouchableOpacity>
     </View>
   )

--- a/components/ExpandableDescription/ExpandableDescription.tsx
+++ b/components/ExpandableDescription/ExpandableDescription.tsx
@@ -3,6 +3,7 @@ import { View, Text, TouchableOpacity } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { black } from '../../assets/colors/colors'
 import { styles } from './styles'
+import { globalStyles } from '../../assets/global/globalStyles'
 
 interface ExpandableDescriptionProps {
   description: string;
@@ -13,9 +14,9 @@ const ExpandableDescription: React.FC<ExpandableDescriptionProps> = ({ descripti
   const [limitNbLines, setLimitNbLines] = useState(true)
 
   return (
-    <View>
+    <View style={styles.container}>
       <Text 
-          style={styles.text}
+          style={[globalStyles.smallText, styles.text]}
           numberOfLines={limitNbLines ? initialNbLines : undefined}>
           {description}
         </Text>

--- a/components/ExpandableDescription/styles.ts
+++ b/components/ExpandableDescription/styles.ts
@@ -6,6 +6,5 @@ export const styles = StyleSheet.create({
     },
     text:{
         fontSize: 12,
-        paddingHorizontal: 10,
     },
 })

--- a/components/ExpandableDescription/styles.ts
+++ b/components/ExpandableDescription/styles.ts
@@ -4,7 +4,12 @@ export const styles = StyleSheet.create({
     button:{
         alignItems: 'center'
     },
-    text:{
-        fontSize: 12,
+    container: {
+        alignItems: 'center',
+        flex: 1,
+        justifyContent: 'center',
     },
+    text: {
+        minWidth: "100%",
+    }
 })

--- a/components/ExpandableDescription/styles.ts
+++ b/components/ExpandableDescription/styles.ts
@@ -1,13 +1,13 @@
-import { StyleSheet } from 'react-native'
+import { StyleSheet } from "react-native"
 
 export const styles = StyleSheet.create({
     button:{
-        alignItems: 'center'
+        alignItems: "center"
     },
     container: {
-        alignItems: 'center',
+        alignItems: "center",
         flex: 1,
-        justifyContent: 'center',
+        justifyContent: "center",
     },
     text: {
         minWidth: "100%",

--- a/components/GeneralProfile/GeneralProfile.tsx
+++ b/components/GeneralProfile/GeneralProfile.tsx
@@ -3,6 +3,7 @@ import { View, Image, Text } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { styles } from './styles'
 import { black } from '../../assets/colors/colors'
+import { globalStyles } from '../../assets/global/globalStyles'
 
 interface GeneralProfileProps {
     name: string,
@@ -31,11 +32,11 @@ const GeneralProfile: React.FC<GeneralProfileProps> = ({
             </View>
         )}
 
-        <Text style={styles.name}>{name} {surname}</Text>
+        <Text style={globalStyles.boldText}>{name} {surname}</Text>
 
         <View style={styles.horizontalContainer}>
             <Ionicons name='location-outline' size={13} color={black} />
-            <Text style={styles.location}>{location}</Text>
+            <Text style={globalStyles.smallText}>{location}</Text>
         </View>
 
     </View>

--- a/components/GeneralProfile/GeneralProfile.tsx
+++ b/components/GeneralProfile/GeneralProfile.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
-import { View, Image, Text } from 'react-native'
-import { Ionicons } from '@expo/vector-icons'
-import { styles } from './styles'
-import { black } from '../../assets/colors/colors'
-import { globalStyles } from '../../assets/global/globalStyles'
+import React from "react"
+import { View, Image, Text } from "react-native"
+import { Ionicons } from "@expo/vector-icons"
+import { styles } from "./styles"
+import { black } from "../../assets/colors/colors"
+import { globalStyles } from "../../assets/global/globalStyles"
 
 interface GeneralProfileProps {
     name: string,
@@ -16,7 +16,7 @@ const GeneralProfile: React.FC<GeneralProfileProps> = ({
     surname,
     location
 }) => {
-  const profilePictureUrl = ''
+  const profilePictureUrl = ""
 
   return (
     <View style={styles.container}>
@@ -28,14 +28,14 @@ const GeneralProfile: React.FC<GeneralProfileProps> = ({
             />
         ) : (
             <View style={styles.profilePicture}>
-                <Ionicons name='person' size={45} color={black} />
+                <Ionicons name="person" size={45} color={black} />
             </View>
         )}
 
         <Text style={globalStyles.boldText}>{name} {surname}</Text>
 
         <View style={styles.horizontalContainer}>
-            <Ionicons name='location-outline' size={13} color={black} />
+            <Ionicons name="location-outline" size={13} color={black} />
             <Text style={globalStyles.smallText}>{location}</Text>
         </View>
 

--- a/components/GeneralProfile/GeneralProfile.tsx
+++ b/components/GeneralProfile/GeneralProfile.tsx
@@ -27,14 +27,14 @@ const GeneralProfile: React.FC<GeneralProfileProps> = ({
             />
         ) : (
             <View style={styles.profilePicture}>
-                <Ionicons name='person' size={50} color={black} />
+                <Ionicons name='person' size={45} color={black} />
             </View>
         )}
 
         <Text style={styles.name}>{name} {surname}</Text>
 
         <View style={styles.horizontalContainer}>
-            <Ionicons name='location-outline' size={14} color={black} />
+            <Ionicons name='location-outline' size={13} color={black} />
             <Text style={styles.location}>{location}</Text>
         </View>
 

--- a/components/GeneralProfile/styles.ts
+++ b/components/GeneralProfile/styles.ts
@@ -1,22 +1,22 @@
-import { StyleSheet } from 'react-native'
-import { peach } from '../../assets/colors/colors'
+import { StyleSheet } from "react-native"
+import { peach } from "../../assets/colors/colors"
 
 export const styles = StyleSheet.create({
     container: {
-        alignContent: 'center',
+        alignContent: "center",
         flex: 1,
-        justifyContent: 'center',
+        justifyContent: "center",
     },
     horizontalContainer: {
         flex: 1,
-        flexDirection: 'row'
+        flexDirection: "row"
     },
     profilePicture: {
-        alignItems: 'center',
+        alignItems: "center",
         backgroundColor: peach,
         borderRadius: 40, // to make it circular
         height: 80,
-        justifyContent: 'center',
+        justifyContent: "center",
         width: 80,
     },
 

--- a/components/GeneralProfile/styles.ts
+++ b/components/GeneralProfile/styles.ts
@@ -3,17 +3,13 @@ import { peach } from '../../assets/colors/colors'
 
 export const styles = StyleSheet.create({
     container: {
+        alignContent: 'center',
+        flex: 1,
         justifyContent: 'center',
     },
     horizontalContainer: {
+        flex: 1,
         flexDirection: 'row'
-    },
-    location: {
-        fontSize: 11,
-    },
-    name: {
-        fontSize: 13,
-        fontWeight: 'bold',
     },
     profilePicture: {
         alignItems: 'center',

--- a/components/GeneralProfile/styles.ts
+++ b/components/GeneralProfile/styles.ts
@@ -4,8 +4,6 @@ import { peach } from '../../assets/colors/colors'
 export const styles = StyleSheet.create({
     container: {
         justifyContent: 'center',
-        left: 10,
-        margin: 10,
     },
     horizontalContainer: {
         flexDirection: 'row'
@@ -14,9 +12,8 @@ export const styles = StyleSheet.create({
         fontSize: 11,
     },
     name: {
-        fontSize: 16,
+        fontSize: 13,
         fontWeight: 'bold',
-        marginVertical: 5,
     },
     profilePicture: {
         alignItems: 'center',

--- a/navigation/Registration/RegistrationStackNavigator.tsx
+++ b/navigation/Registration/RegistrationStackNavigator.tsx
@@ -7,6 +7,8 @@ import HomeTabNavigator from "../../navigation/Home/HomeTabNavigator"
 import { MyProfileScreen } from "../../screens/Profile/MyProfileScreen/MyProfileScreen"
 import { SettingsScreen } from "../../screens/Settings/SettingsScreen"
 import AuthenticationScreen from "../../screens/Registration/AuthenticationScreen/AuthenticationScreen"
+import { MyQrCodeScreen } from "../../screens/Profile/MyQrCode/MyQrCodeScreen"
+import { UpdateMyProfileScreen } from "../../screens/Profile/UpdateMyProfile/UpdateMyProfileScreen"
 
 const Stack = createStackNavigator()
 
@@ -42,6 +44,16 @@ const RegistrationStackNavigator: React.FC = () => {
       <Stack.Screen
         name="Profile"
         component={MyProfileScreen}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="My QR code"
+        component={MyQrCodeScreen}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="Update my profile"
+        component={UpdateMyProfileScreen}
         options={{ headerShown: false }}
       />
       <Stack.Screen

--- a/navigation/Registration/RegistrationStackNavigator.tsx
+++ b/navigation/Registration/RegistrationStackNavigator.tsx
@@ -47,12 +47,12 @@ const RegistrationStackNavigator: React.FC = () => {
         options={{ headerShown: false }}
       />
       <Stack.Screen
-        name="My QR code"
+        name="MyQR"
         component={MyQrCodeScreen}
         options={{ headerShown: false }}
       />
       <Stack.Screen
-        name="Update my profile"
+        name="UpdateProfile"
         component={UpdateMyProfileScreen}
         options={{ headerShown: false }}
       />

--- a/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
+++ b/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
@@ -37,29 +37,23 @@ export const MyProfileScreen = () => {
 
   return (
     <View style={styles.container}>
-
       <View style={styles.topBackground} />
-
       <View style={styles.profileContainer}>
 
-        <View style={styles.horizontalContainer}>
+        <View style={styles.topProfileContainer}>
 
-          <View style={styles.leftAlign}>
-            <GeneralProfile
-              name={dummyProfile.firstName}
-              surname={dummyProfile.lastName}
-              location={dummyProfile.location}
-            />
-          </View>
-
-          <View style={styles.horizontalContainer}>
-
+          <GeneralProfile
+            name={dummyProfile.firstName}
+            surname={dummyProfile.lastName}
+            location={dummyProfile.location}
+          />
+          
+          <View style={styles.buttonsContainer}>
             <TouchableOpacity 
               style={styles.button}
               onPress={() => useNav.navigate("UpdateProfile" as never)}>
               <Text style={[globalStyles.boldText, styles.buttonText]}>Update</Text>
             </TouchableOpacity>
-
             <TouchableOpacity 
               style={styles.button}
               onPress={() => useNav.navigate("MyQR" as never)}>
@@ -68,7 +62,6 @@ export const MyProfileScreen = () => {
                 <Text style={[globalStyles.boldText, styles.buttonText]}>QR</Text>
               </View>
             </TouchableOpacity>
-
           </View>
 
         </View>
@@ -79,7 +72,6 @@ export const MyProfileScreen = () => {
 
         <View style={styles.separatorLine} />
 
-
         <View style={styles.horizontalContainer}>
           <InputField
             label=""
@@ -88,13 +80,12 @@ export const MyProfileScreen = () => {
             onChangeText={text => setSearch(text)}>
           </InputField>
         </View>
-
+      
         <View style={styles.container}>
 
         </View>
 
       </View>
-
     </View>
   )
 }

--- a/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
+++ b/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
@@ -6,6 +6,7 @@ import { styles } from "./styles"
 import { black } from "../../../assets/colors/colors"
 import InputField from "../../../components/InputField/InputField"
 import { useState } from "react"
+import { useNavigation } from "@react-navigation/native"
 
 type Contact = {
   uid: string
@@ -18,7 +19,7 @@ type Contact = {
   location: string
 }
 
-const dummyProfile1: Contact = {
+const dummyProfile: Contact = {
   uid: "4",
   firstName: "Hervé",
   lastName: "DelaMontagne",
@@ -29,21 +30,9 @@ const dummyProfile1: Contact = {
   location: "EPFL Ecublens"
 }
 
-//const dummyProfile2: Contact = {
-//  uid: "4",
-//  firstName: "Hervé",
-//  lastName: "DelaMontagnophobe",
-//  profilePictureUrl: "",
-//  description: "Description, description, description, loooooooooong descriiiiiiiiiiption, this is a veeeeeeeeeeeeeeeeeeeeeery loooooooooooooooooooooooooooooooooooooooooooong descriiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiption alala",
-//  interests: ["running"],
-//  qualifications: ["bowling"],
-//  location: "EPFL Ecublens"
-//}
-
-const dummyProfile = dummyProfile1
-
 export const MyProfileScreen = () => {
   const [search, setSearch] = useState("")
+  const useNav = useNavigation()
 
   return (
     <View style={styles.container}>
@@ -64,11 +53,15 @@ export const MyProfileScreen = () => {
 
           <View style={styles.horizontalContainer}>
 
-            <TouchableOpacity style={styles.button}>
+            <TouchableOpacity 
+              style={styles.button}
+              onPress={() => useNav.navigate("Update my profile" as never)}>
               <Text style={styles.buttonText}>Update</Text>
             </TouchableOpacity>
 
-            <TouchableOpacity style={styles.button}>
+            <TouchableOpacity 
+              style={styles.button}
+              onPress={() => useNav.navigate("My QR code" as never)}>
               <View style={styles.horizontalContainer}>
                 <Ionicons name="qr-code" size={14} color={black} />
                 <Text style={styles.buttonText}>QR</Text>

--- a/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
+++ b/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
@@ -55,13 +55,13 @@ export const MyProfileScreen = () => {
 
             <TouchableOpacity 
               style={styles.button}
-              onPress={() => useNav.navigate("Update my profile" as never)}>
+              onPress={() => useNav.navigate("UpdateProfile" as never)}>
               <Text style={styles.buttonText}>Update</Text>
             </TouchableOpacity>
 
             <TouchableOpacity 
               style={styles.button}
-              onPress={() => useNav.navigate("My QR code" as never)}>
+              onPress={() => useNav.navigate("MyQR" as never)}>
               <View style={styles.horizontalContainer}>
                 <Ionicons name="qr-code" size={14} color={black} />
                 <Text style={styles.buttonText}>QR</Text>

--- a/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
+++ b/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
@@ -7,6 +7,7 @@ import { black } from "../../../assets/colors/colors"
 import InputField from "../../../components/InputField/InputField"
 import { useState } from "react"
 import { useNavigation } from "@react-navigation/native"
+import { globalStyles } from "../../../assets/global/globalStyles"
 
 type Contact = {
   uid: string
@@ -56,7 +57,7 @@ export const MyProfileScreen = () => {
             <TouchableOpacity 
               style={styles.button}
               onPress={() => useNav.navigate("UpdateProfile" as never)}>
-              <Text style={styles.buttonText}>Update</Text>
+              <Text style={[globalStyles.boldText, styles.buttonText]}>Update</Text>
             </TouchableOpacity>
 
             <TouchableOpacity 
@@ -64,7 +65,7 @@ export const MyProfileScreen = () => {
               onPress={() => useNav.navigate("MyQR" as never)}>
               <View style={styles.horizontalContainer}>
                 <Ionicons name="qr-code" size={14} color={black} />
-                <Text style={styles.buttonText}>QR</Text>
+                <Text style={[globalStyles.boldText, styles.buttonText]}>QR</Text>
               </View>
             </TouchableOpacity>
 

--- a/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
+++ b/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
@@ -1,23 +1,98 @@
-import { View } from 'react-native'
-import { styles } from './styles'
+import { Text, View, TouchableOpacity } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
 import ExpandableDescription from '../../../components/ExpandableDescription/ExpandableDescription'
 import GeneralProfile from '../../../components/GeneralProfile/GeneralProfile'
+import { styles } from './styles'
+import { black } from '../../../assets/colors/colors'
+import InputField from '../../../components/InputField/InputField'
+import { useState } from 'react'
+
+type Contact = {
+  uid: string
+  firstName: string
+  lastName: string
+  profilePictureUrl?: string
+  description: string
+  interests: string[]
+  qualifications: string[],
+  location: string
+}
+
+const dummyProfile1: Contact = {
+  uid: "4",
+  firstName: "Hervé",
+  lastName: "Dela",
+  profilePictureUrl: "",
+  description: "Description, description, descrc hdsjklaf hel fhj fdj bjhd vbfdhj vbdjhl vdjlh vdhj vfdjh hvdu vdh vdfj vdfs hfdj fdj vdfjl d grei hrj heiua fjispd jis gjdrkl gjreks reksl grei gril nrsj njiption, loooooooooong descriiiiiiiiiiption, this is a veeeeeeeeeeeeeeeeeeeeeery loooooooooooooooooooooooooooooooooooooooooooong descriiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiption alala",
+  interests: ["running"],
+  qualifications: ["bowling"],
+  location: "EPFL Ecublens"
+}
+
+//const dummyProfile2: Contact = {
+//  uid: "4",
+//  firstName: "Hervé",
+//  lastName: "DelaMontagnophobe",
+//  profilePictureUrl: "",
+//  description: "Description, description, description, loooooooooong descriiiiiiiiiiption, this is a veeeeeeeeeeeeeeeeeeeeeery loooooooooooooooooooooooooooooooooooooooooooong descriiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiption alala",
+//  interests: ["running"],
+//  qualifications: ["bowling"],
+//  location: "EPFL Ecublens"
+//}
+
+const dummyProfile = dummyProfile1
 
 export const MyProfileScreen = () => {
+  const [search, setSearch] = useState('')
+
   return (
-    <View style={styles.view}>
+    <View style={styles.container}>
 
-      <View style={styles.leftAlign}>
-        <GeneralProfile
-          name={'Name'}
-          surname={'Surname'}
-          location={'le Mont-sur-Lausanne'}
+      <View style={styles.topBackground} />
+
+      <View style={styles.profileContainer}>
+
+        <View style={styles.horizontalContainer}>
+
+          <View style={styles.leftAlign}>
+            <GeneralProfile
+              name={dummyProfile.firstName}
+              surname={dummyProfile.lastName}
+              location={dummyProfile.location}
+            />
+          </View>
+
+          <View style={styles.horizontalContainer}>
+
+            <TouchableOpacity style={styles.button}>
+              <Text style={styles.buttonText}>Update</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity style={styles.button}>
+              <View style={styles.horizontalContainer}>
+                <Ionicons name='qr-code' size={14} color={black} />
+                <Text style={styles.buttonText}>QR</Text>
+              </View>
+            </TouchableOpacity>
+
+          </View>
+
+        </View>
+
+        <ExpandableDescription
+          description={dummyProfile.description}
         />
-      </View>
 
-      <ExpandableDescription
-        description={'slajfeiohadslh oh ho sdhv lsvnjls bvdfjl vj shdls hvueri hvueos hvurei shvureio vhruieo vhuris hviuds vnfjd re vuirep uir hfeuiphgfure fhueir hguriewp hfurie hfruie hfuire hfure uire uier huirs hui bhuero vureso huire hure hzureepseo guers hvuip vuip hurieps hurips hvurips bhutrid bhurtipd hbuips hurieps huiers vhurieps vuries hvureips hureis bfhres fures huirpe burip vuirso hvzureo gfuersh guirp hutirp hveruips vuresp hv'}
-      />
+        <View style={styles.separatorLine} />
+
+        <InputField
+          label=''
+          placeholder='Search...'
+          value={search}
+          onChangeText={text => setSearch(text)}>
+        </InputField>
+
+      </View>
 
     </View>
   )

--- a/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
+++ b/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
@@ -1,11 +1,11 @@
-import { Text, View, TouchableOpacity } from 'react-native'
-import { Ionicons } from '@expo/vector-icons'
-import ExpandableDescription from '../../../components/ExpandableDescription/ExpandableDescription'
-import GeneralProfile from '../../../components/GeneralProfile/GeneralProfile'
-import { styles } from './styles'
-import { black } from '../../../assets/colors/colors'
-import InputField from '../../../components/InputField/InputField'
-import { useState } from 'react'
+import { Text, View, TouchableOpacity } from "react-native"
+import { Ionicons } from "@expo/vector-icons"
+import ExpandableDescription from "../../../components/ExpandableDescription/ExpandableDescription"
+import GeneralProfile from "../../../components/GeneralProfile/GeneralProfile"
+import { styles } from "./styles"
+import { black } from "../../../assets/colors/colors"
+import InputField from "../../../components/InputField/InputField"
+import { useState } from "react"
 
 type Contact = {
   uid: string
@@ -21,7 +21,7 @@ type Contact = {
 const dummyProfile1: Contact = {
   uid: "4",
   firstName: "Hervé",
-  lastName: "Dela",
+  lastName: "DelaMontagne",
   profilePictureUrl: "",
   description: "Description, description, descrc hdsjklaf hel fhj fdj bjhd vbfdhj vbdjhl vdjlh vdhj vfdjh hvdu vdh vdfj vdfs hfdj fdj vdfjl d grei hrj heiua fjispd jis gjdrkl gjreks reksl grei gril nrsj njiption, loooooooooong descriiiiiiiiiiption, this is a veeeeeeeeeeeeeeeeeeeeeery loooooooooooooooooooooooooooooooooooooooooooong descriiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiption alala",
   interests: ["running"],
@@ -43,7 +43,7 @@ const dummyProfile1: Contact = {
 const dummyProfile = dummyProfile1
 
 export const MyProfileScreen = () => {
-  const [search, setSearch] = useState('')
+  const [search, setSearch] = useState("")
 
   return (
     <View style={styles.container}>
@@ -70,7 +70,7 @@ export const MyProfileScreen = () => {
 
             <TouchableOpacity style={styles.button}>
               <View style={styles.horizontalContainer}>
-                <Ionicons name='qr-code' size={14} color={black} />
+                <Ionicons name="qr-code" size={14} color={black} />
                 <Text style={styles.buttonText}>QR</Text>
               </View>
             </TouchableOpacity>
@@ -85,12 +85,19 @@ export const MyProfileScreen = () => {
 
         <View style={styles.separatorLine} />
 
-        <InputField
-          label=''
-          placeholder='Search...'
-          value={search}
-          onChangeText={text => setSearch(text)}>
-        </InputField>
+
+        <View style={styles.horizontalContainer}>
+          <InputField
+            label=""
+            placeholder="Search..."
+            value={search}
+            onChangeText={text => setSearch(text)}>
+          </InputField>
+        </View>
+
+        <View style={styles.container}>
+
+        </View>
 
       </View>
 

--- a/screens/Profile/MyProfileScreen/styles.ts
+++ b/screens/Profile/MyProfileScreen/styles.ts
@@ -16,7 +16,6 @@ export const styles = StyleSheet.create({
   buttonText: {
     alignItems: "center",
     fontSize: 12,
-    fontWeight: "bold",
     justifyContent: "center",
     margin: 1,
   },
@@ -24,9 +23,6 @@ export const styles = StyleSheet.create({
     alignItems: "center",
     flex: 1,
     justifyContent: "center",
-  },
-  descriptionStyle: {
-    width: "100%"
   },
   horizontalContainer: {
     alignItems: "center",

--- a/screens/Profile/MyProfileScreen/styles.ts
+++ b/screens/Profile/MyProfileScreen/styles.ts
@@ -39,11 +39,10 @@ export const styles = StyleSheet.create({
   },
   profileContainer: {
     flex: 1,
-    marginTop: -35,
+    marginTop: -44,
+    padding: 10,
   },
-  searchBar: {
-    
-  },
+
   separatorLine: {
     backgroundColor: black,
     height: 1,

--- a/screens/Profile/MyProfileScreen/styles.ts
+++ b/screens/Profile/MyProfileScreen/styles.ts
@@ -1,13 +1,58 @@
-import { StyleSheet } from 'react-native'
+import { StyleSheet } from "react-native"
+import { black, lightPeach, peach } from "../../../assets/colors/colors"
 
 export const styles = StyleSheet.create({
-  leftAlign: {
-    alignSelf: 'flex-start'
+  button: {
+    alignItems: "center",
+    backgroundColor: lightPeach,
+    borderColor: peach,
+    borderRadius: 10,
+    borderWidth: 2,
+    height: 38,
+    justifyContent: "center",
+    marginLeft: 14,
+    width: 90,
   },
-  view: {
-    alignItems: 'center',
+  buttonText: {
+    alignItems: "center",
+    fontSize: 12,
+    fontWeight: "bold",
+    justifyContent: "center",
+    margin: 1,
+  },
+  container: {
+    alignItems: "center",
     flex: 1,
-    justifyContent: 'center'
+    justifyContent: "center",
+  },
+  descriptionStyle: {
+    width: "100%"
+  },
+  horizontalContainer: {
+    alignItems: "center",
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  leftAlign: {
+    alignSelf: "flex-start",
+    flex: 1,
+  },
+  profileContainer: {
+    flex: 1,
+    marginTop: -35,
+  },
+  searchBar: {
+    
+  },
+  separatorLine: {
+    backgroundColor: black,
+    height: 1,
+    width: "auto",
+  },
+  topBackground: {
+    backgroundColor: lightPeach,
+    height: 160,
+    width: "100%"
   },
   
 })

--- a/screens/Profile/MyProfileScreen/styles.ts
+++ b/screens/Profile/MyProfileScreen/styles.ts
@@ -8,16 +8,22 @@ export const styles = StyleSheet.create({
     borderColor: peach,
     borderRadius: 10,
     borderWidth: 2,
-    height: 38,
+    elevation: 6,
+    height: "33%",
     justifyContent: "center",
-    marginLeft: 14,
-    width: 90,
+    width: "45%",
   },
   buttonText: {
     alignItems: "center",
-    fontSize: 12,
+    fontSize: 13,
     justifyContent: "center",
     margin: 1,
+  },
+  buttonsContainer: {
+    alignItems: "center",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    width: "55%",
   },
   container: {
     alignItems: "center",
@@ -26,19 +32,16 @@ export const styles = StyleSheet.create({
   },
   horizontalContainer: {
     alignItems: "center",
+    flex: 1,
     flexDirection: "row",
     justifyContent: "space-between",
   },
-  leftAlign: {
-    alignSelf: "flex-start",
-    flex: 1,
-  },
   profileContainer: {
     flex: 1,
-    marginTop: -44,
-    padding: 10,
+    marginHorizontal: 10,
+    position: "absolute",
+    top: 0,
   },
-
   separatorLine: {
     backgroundColor: black,
     height: 1,
@@ -46,8 +49,16 @@ export const styles = StyleSheet.create({
   },
   topBackground: {
     backgroundColor: lightPeach,
-    height: 160,
+    height: "20%",
+    position: "absolute",
+    top: 0,
     width: "100%"
+  },
+  topProfileContainer: {
+    flexDirection: "row",
+    flex: 1,
+    marginBottom: 4,
+    marginTop: "35%",
   },
   
 })

--- a/screens/Profile/MyQrCode/MyQrCodeScreen.tsx
+++ b/screens/Profile/MyQrCode/MyQrCodeScreen.tsx
@@ -1,10 +1,11 @@
 import { View } from "react-native"
 import { Ionicons } from '@expo/vector-icons'
 import { black } from "../../../assets/colors/colors"
+import { styles } from "./styles"
 
 export const MyQrCodeScreen = () => {
   return (
-    <View >
+    <View style={styles.container}>
         <Ionicons name='qr-code' size={200} color={black} />
     </View>
   )

--- a/screens/Profile/MyQrCode/MyQrCodeScreen.tsx
+++ b/screens/Profile/MyQrCode/MyQrCodeScreen.tsx
@@ -1,0 +1,11 @@
+import { View } from "react-native"
+import { Ionicons } from '@expo/vector-icons'
+import { black } from "../../../assets/colors/colors"
+
+export const MyQrCodeScreen = () => {
+  return (
+    <View >
+        <Ionicons name='qr-code' size={200} color={black} />
+    </View>
+  )
+}

--- a/screens/Profile/MyQrCode/styles.ts
+++ b/screens/Profile/MyQrCode/styles.ts
@@ -1,0 +1,5 @@
+import { StyleSheet } from "react-native"
+
+export const styles = StyleSheet.create({
+
+})

--- a/screens/Profile/MyQrCode/styles.ts
+++ b/screens/Profile/MyQrCode/styles.ts
@@ -1,5 +1,9 @@
 import { StyleSheet } from "react-native"
 
 export const styles = StyleSheet.create({
-
+    container: {
+        alignItems: "center",
+        flex: 1,
+        justifyContent: "center",
+    }
 })

--- a/screens/Profile/UpdateMyProfile/UpdateMyProfileScreen.tsx
+++ b/screens/Profile/UpdateMyProfile/UpdateMyProfileScreen.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from "react-native"
+
+export const UpdateMyProfileScreen = () => {
+  return (
+    <View >
+      <Text>This is the Externalprofile screen</Text>
+    </View>
+  )
+}

--- a/screens/Profile/UpdateMyProfile/UpdateMyProfileScreen.tsx
+++ b/screens/Profile/UpdateMyProfile/UpdateMyProfileScreen.tsx
@@ -1,9 +1,10 @@
 import { View, Text } from "react-native"
+import { styles } from "./styles"
 
 export const UpdateMyProfileScreen = () => {
   return (
-    <View >
-      <Text>This is the Externalprofile screen</Text>
+    <View style={styles.container}>
+      <Text>This is the update my profile screen</Text>
     </View>
   )
 }

--- a/screens/Profile/UpdateMyProfile/styles.ts
+++ b/screens/Profile/UpdateMyProfile/styles.ts
@@ -1,0 +1,5 @@
+import { StyleSheet } from "react-native"
+
+export const styles = StyleSheet.create({
+
+})

--- a/screens/Profile/UpdateMyProfile/styles.ts
+++ b/screens/Profile/UpdateMyProfile/styles.ts
@@ -1,5 +1,9 @@
 import { StyleSheet } from "react-native"
 
 export const styles = StyleSheet.create({
-
+    container: {
+        alignItems: "center",
+        flex: 1,
+        justifyContent: "center",
+    }
 })


### PR DESCRIPTION
# What I did
Implemented a part of the "my profile screen". The lower part with events and interests is not implemented yet. I intend to implement it in another PR (or someone else can do it). The screen is usable nonetheless.

# How I did it
- Implemented the screen in MyProfileScreen.
- Slightly modified GeneralProfile and ExpandableDescription component to make them easier to use.
- Created MyQrCodeScreen and UpdateMyProfileScreen so we can navigate to them from the MyProfileScreen
- Added tests for MyProfileScreen, GeneralProfile and ExpandableDescription

# How to verify it

You can go to "my profile" by clicking on the top left of the screen. You can also run the tests.

# Demo video

https://github.com/uniconnect-epfl/uniconnect/assets/93329823/ca86691b-d9f0-4894-a1af-9457a1f5a90d

# Pre-merge checklist
The changes I have introduced:
- [x] work correctly
- [x] do not break other functionalities
- [x] work correctly on Android
- [x] are fully tested