### PR TITLE
feat: screen scan qr

### DIFF
--- a/__test__/components/TabBar/TabBar.test.tsx
+++ b/__test__/components/TabBar/TabBar.test.tsx
@@ -37,17 +37,15 @@ describe("TabBar", () => {
     const connections = getByText("Connections")
     const explore = getByText("Explore")
 
-    fireEvent.press(connections)
-
-    expect(getByText("Plain View")).toBeTruthy()
-
     fireEvent.press(home)
 
-    expect(getByText("Home")).toBeTruthy()
+    expect(getByText("Show on the Map")).toBeTruthy()
 
     fireEvent.press(explore)
 
     expect(getByText("Plain View")).toBeTruthy()
+
+    fireEvent.press(connections)
 
   })
 })

--- a/__test__/screens/QrScan/QrScanScreen.test.tsx
+++ b/__test__/screens/QrScan/QrScanScreen.test.tsx
@@ -1,10 +1,109 @@
-import React from 'react'
-import { render } from '@testing-library/react-native'
-import QrScanScreen from '../../../screens/QrScan/QrScanScreen'
+import React from "react"
+import { act, fireEvent, render } from "@testing-library/react-native"
+import QrScanScreen from "../../../screens/QrScan/QrScanScreen"
+import { NavigationContainer } from "@react-navigation/native"
+import { Alert } from "react-native"
+import { Camera } from "expo-camera"
 
-describe('QrScanScreen', () => {
-    it('renders correctly', () => {
-        const component = render(<QrScanScreen/>)
+jest.mock('expo-camera', () => {
+    const actual = jest.requireActual('expo-camera')
+
+    const camera = actual.Camera
+
+    camera.useCameraPermissions = jest.fn().mockImplementation(() => {
+
+        const requestPermission = () => {
+            console.log('request permission called')
+            return Promise.resolve({ status: 'denied' })
+        }
+
+        const permission = 'granted' // set the value you want
+
+        return [
+            permission, 
+            requestPermission
+          
+        ]
+    })
+
+    console.log('camera', camera)
+
+    return {
+        __esModule: true,
+        ...actual,
+        Camera: camera
+    }
+
+})
+
+jest.mock("@react-navigation/native", () => {
+    return {
+      ...jest.requireActual("@react-navigation/native"), // use actual for all non-hook parts
+      useIsFocused: () => true,
+      useNavigation: () => ({
+        navigate: jest.fn(),
+        // Add other navigation functions that your component uses
+      }),
+      useRoute: () => ({
+        params: {},
+        // Mock other route properties as needed
+      }),
+    }
+})
+
+describe("QrScanScreen", () => {
+
+    it("renders correctly", () => {
+        const component = render(
+          <NavigationContainer>
+            <QrScanScreen/>
+          </NavigationContainer>
+        )
         expect(component).toBeTruthy()
     })
+
+    it("renders the camera when permissions are granted", () => {
+        (Camera.useCameraPermissions as jest.Mock).mockImplementation(() => [{
+          granted: true
+      }, jest.fn()])
+
+      const { getByTestId } = render(
+        <NavigationContainer>
+          <QrScanScreen/>
+        </NavigationContainer>
+      )
+      expect(getByTestId("camera")).toBeTruthy()
+    })
+  
+    it("handles barcode scanned", () => {
+      (Camera.useCameraPermissions as jest.Mock).mockImplementation(() => [{
+          granted: true
+      }, jest.fn()])
+      jest.spyOn(Alert, 'alert')
+      const { getByTestId } = render(
+        <NavigationContainer>
+          <QrScanScreen />
+        </NavigationContainer>
+      )
+      act(() => {
+        fireEvent(getByTestId("camera"), "onBarCodeScanned", {
+          nativeEvent: { type: "qr", data: "123" }
+        })
+      })
+      expect(Alert.alert).toHaveBeenCalled()
+      jest.clearAllMocks()
+    })
+  
+    it("requests permission when not granted", () => {
+        (Camera.useCameraPermissions as jest.Mock).mockImplementation(() => [{
+          granted: false
+      }, jest.fn()])
+      const { getByText } = render(
+        <NavigationContainer>
+          <QrScanScreen />
+        </NavigationContainer>
+      )
+      fireEvent.press(getByText("Authorize"))
+    })
+    
 })

--- a/__test__/screens/QrScan/QrScanScreen.test.tsx
+++ b/__test__/screens/QrScan/QrScanScreen.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import QrScanScreen from '../../../screens/QrScan/QrScanScreen'
+
+describe('QrScanScreen', () => {
+    it('renders correctly', () => {
+        const component = render(<QrScanScreen/>)
+        expect(component).toBeTruthy()
+    })
+})

--- a/app.json
+++ b/app.json
@@ -1,5 +1,13 @@
 {
   "expo": {
+    "plugins": [
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "Allow $(PRODUCT_NAME) to access your camera"
+        }
+      ]
+    ],
     "name": "uni-connect",
     "slug": "uniconnect",
     "scheme" : "uniconnect",

--- a/app.json
+++ b/app.json
@@ -1,13 +1,5 @@
 {
   "expo": {
-    "plugins": [
-      [
-        "expo-camera",
-        {
-          "cameraPermission": "Allow $(PRODUCT_NAME) to access your camera"
-        }
-      ]
-    ],
     "name": "uni-connect",
     "slug": "uniconnect",
     "scheme" : "uniconnect",

--- a/navigation/Home/HomeTabNavigator.tsx
+++ b/navigation/Home/HomeTabNavigator.tsx
@@ -4,6 +4,7 @@ import HomeScreen from '../../screens/Home/HomeScreen'
 import { TabBar } from '../../components/TabBar/TabBar'
 import { Header } from '../../components/Header/Header'
 import ExploreScreen from '../../screens/Contacts/ExploreScreen'
+import QrScanScreen from '../../screens/QrScan/QrScanScreen'
 
 const Tab = createBottomTabNavigator()
 
@@ -18,7 +19,7 @@ const HomeTabNavigator = () => {
       }}
     >
       <Tab.Screen name="Home" component={HomeScreen}/>
-      <Tab.Screen name="Connections" component={ExploreScreen}/>
+      <Tab.Screen name="Connections" component={QrScanScreen}/>
       <Tab.Screen name="Explore" component={ExploreScreen}/>
     </Tab.Navigator>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "expo": "~50.0.11",
         "expo-application": "~5.8.4",
         "expo-auth-session": "~5.4.0",
+        "expo-camera": "~14.1.3",
         "expo-crypto": "~12.8.1",
         "expo-dev-client": "~3.3.11",
         "expo-splash-screen": "~0.26.4",
@@ -12219,6 +12220,17 @@
         "expo-linking": "~6.2.0",
         "expo-web-browser": "~12.8.0",
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-camera": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-14.1.3.tgz",
+      "integrity": "sha512-JodpVjOY8JDuSp/RkphS8Bxqaj/gwg0h0UbQB9MLr1LoxbL9brvJt7IZnmTf7+ON8jRKUx9E5o/F02pRNbmSbQ==",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-constants": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "expo-status-bar": "~1.11.1",
     "expo-web-browser": "~12.8.2",
     "expo-application": "~5.8.4",
+    "expo-camera": "~14.1.3",
     "firebase": "^10.11.0",
     "jest": "^29.3.1",
     "jest-expo": "~50.0.4",

--- a/screens/QrScan/QrScanScreen.tsx
+++ b/screens/QrScan/QrScanScreen.tsx
@@ -71,12 +71,17 @@ const QrScanScreen = () => {
       <Text style={[globalStyles.text, styles.scanAQrText]}>Scan a QR code</Text>
       {showCamera ? (
         <Camera 
+          testID="camera"
           style={styles.camera}
           onBarCodeScanned={handleBarCodeScanned}
         />
       ) : (
         <View style={styles.container}>
-          <ActivityIndicator size="large" color={peach} />
+          <ActivityIndicator
+            testID="activity-indicator" 
+            size="large" 
+            color={peach} 
+          />
         </View>
       )}
 

--- a/screens/QrScan/QrScanScreen.tsx
+++ b/screens/QrScan/QrScanScreen.tsx
@@ -1,8 +1,8 @@
+import React, { useEffect, useState } from "react"
 import { View, Text, TouchableOpacity, Alert, ActivityIndicator } from "react-native"
 import { BarCodeScanningResult, Camera } from "expo-camera"
 import { styles } from "./styles"
 import { globalStyles } from "../../assets/global/globalStyles"
-import { useEffect, useState } from "react"
 import { useIsFocused } from "@react-navigation/native"
 import { peach } from "../../assets/colors/colors"
 

--- a/screens/QrScan/QrScanScreen.tsx
+++ b/screens/QrScan/QrScanScreen.tsx
@@ -1,10 +1,31 @@
-import { View, Text, TouchableOpacity } from "react-native"
-import { Camera } from "expo-camera"
+import { View, Text, TouchableOpacity, Alert } from "react-native"
+import { BarCodeScanningResult, Camera } from "expo-camera"
 import { styles } from "./styles"
 import { globalStyles } from "../../assets/global/globalStyles"
+import { useIsFocused } from "@react-navigation/native"
+import { useState } from "react"
 
 const QrScanScreen = () => {
+  const isFocused = useIsFocused()
   const [permission, requestPermission] = Camera.useCameraPermissions()
+  const [qrScanned, setQrScanned] = useState(false)
+
+  const handleBarCodeScanned = ({ type, data }: BarCodeScanningResult): void => {
+    if(!qrScanned){
+      setQrScanned(true)
+      Alert.alert(
+        "QR scanned", 
+        `type: ${type}\ndata:${data}`,
+        [
+          { 
+            text: "OK", 
+            onPress: () => setQrScanned(false)
+          },
+        ],
+        { cancelable: false }
+      )
+    }
+  }
 
   if (!permission) {
     // Camera permissions are still loading
@@ -34,8 +55,13 @@ const QrScanScreen = () => {
 
   return (
     <View style={styles.container}>
-      <Text>Scan Qr</Text>
-      <Camera />
+
+      <Text style={[globalStyles.text, styles.scanAQrText]}>Scan a QR code</Text>
+      {isFocused && <Camera 
+        style={styles.camera}
+        onBarCodeScanned={handleBarCodeScanned}
+      />}
+
     </View>
   )
 }

--- a/screens/QrScan/QrScanScreen.tsx
+++ b/screens/QrScan/QrScanScreen.tsx
@@ -1,0 +1,31 @@
+import { View, Text, Button } from "react-native"
+import { Camera } from "expo-camera"
+import { styles } from "./styles"
+
+const QrScanScreen = () => {
+  const [permission, requestPermission] = Camera.useCameraPermissions()
+
+  if (!permission) {
+    // Camera permissions are still loading
+    return <View />
+  }
+
+  if (!permission.granted) {
+    // Camera permissions are not granted yet
+    return (
+      <View style={styles.container}>
+        <Text style={styles.container}>We need your permission to show the camera</Text>
+        <Button onPress={requestPermission} title="grant permission" />
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text>Scan Qr</Text>
+      <Camera />
+    </View>
+  )
+}
+
+export default QrScanScreen

--- a/screens/QrScan/QrScanScreen.tsx
+++ b/screens/QrScan/QrScanScreen.tsx
@@ -1,14 +1,25 @@
-import { View, Text, TouchableOpacity, Alert } from "react-native"
+import { View, Text, TouchableOpacity, Alert, ActivityIndicator } from "react-native"
 import { BarCodeScanningResult, Camera } from "expo-camera"
 import { styles } from "./styles"
 import { globalStyles } from "../../assets/global/globalStyles"
+import { useEffect, useState } from "react"
 import { useIsFocused } from "@react-navigation/native"
-import { useState } from "react"
+import { peach } from "../../assets/colors/colors"
 
 const QrScanScreen = () => {
   const isFocused = useIsFocused()
   const [permission, requestPermission] = Camera.useCameraPermissions()
+  const [showCamera, setShowCamera] = useState(false)
   const [qrScanned, setQrScanned] = useState(false)
+
+  // to allow mounting and unmounting the camera without slowing navigation
+  useEffect(() => {
+    if (isFocused) {
+      setShowCamera(true)
+    } else {
+      setShowCamera(false)
+    }
+  }, [isFocused])
 
   const handleBarCodeScanned = ({ type, data }: BarCodeScanningResult): void => {
     if(!qrScanned){
@@ -53,14 +64,21 @@ const QrScanScreen = () => {
     )
   }
 
+  // we have camera permissions, we show the camera
   return (
     <View style={styles.container}>
 
       <Text style={[globalStyles.text, styles.scanAQrText]}>Scan a QR code</Text>
-      {isFocused && <Camera 
-        style={styles.camera}
-        onBarCodeScanned={handleBarCodeScanned}
-      />}
+      {showCamera ? (
+        <Camera 
+          style={styles.camera}
+          onBarCodeScanned={handleBarCodeScanned}
+        />
+      ) : (
+        <View style={styles.container}>
+          <ActivityIndicator size="large" color={peach} />
+        </View>
+      )}
 
     </View>
   )

--- a/screens/QrScan/QrScanScreen.tsx
+++ b/screens/QrScan/QrScanScreen.tsx
@@ -1,6 +1,7 @@
-import { View, Text, Button } from "react-native"
+import { View, Text, TouchableOpacity } from "react-native"
 import { Camera } from "expo-camera"
 import { styles } from "./styles"
+import { globalStyles } from "../../assets/global/globalStyles"
 
 const QrScanScreen = () => {
   const [permission, requestPermission] = Camera.useCameraPermissions()
@@ -14,8 +15,19 @@ const QrScanScreen = () => {
     // Camera permissions are not granted yet
     return (
       <View style={styles.container}>
-        <Text style={styles.container}>We need your permission to show the camera</Text>
-        <Button onPress={requestPermission} title="grant permission" />
+        <View style={styles.requestAuthorizationContainer}>
+          <Text style={[globalStyles.boldText, styles.authorizationText]}>
+            We need your permission to show the camera
+          </Text>
+          <TouchableOpacity
+            style={styles.requestAuthorizationsButton}
+            onPress={requestPermission}
+          >
+            <Text style={globalStyles.text}>
+              Authorize
+            </Text>
+          </TouchableOpacity>
+        </View>
       </View>
     )
   }

--- a/screens/QrScan/styles.ts
+++ b/screens/QrScan/styles.ts
@@ -6,11 +6,25 @@ export const styles = StyleSheet.create({
         marginVertical: "20%",
         textAlign: "center"
     },
+    camera: {
+        flex: 1,
+        height: "100%",
+        width: "100%",
+    },
     container: {
         alignItems: "center",
         flex: 1,
         justifyContent: "center",
     },
+    loadingContainer: {
+        alignItems: 'center',
+        bottom: 0,
+        justifyContent: 'center',
+        left: 0,
+        position: 'absolute',
+        right: 0,
+        top: 0,
+      },
     requestAuthorizationContainer: {
         alignItems: "center",
         backgroundColor: lightPeach,
@@ -30,6 +44,9 @@ export const styles = StyleSheet.create({
         marginVertical: "20%",
         width: "70%",
     },
+    scanAQrText: {
+        marginVertical: 20,
+    }
 
 })
   

--- a/screens/QrScan/styles.ts
+++ b/screens/QrScan/styles.ts
@@ -1,10 +1,34 @@
 import { StyleSheet } from "react-native" 
+import { lightPeach, peach } from "../../assets/colors/colors"
 
 export const styles = StyleSheet.create({
+    authorizationText: {
+        marginVertical: "20%",
+        textAlign: "center"
+    },
     container: {
         alignItems: "center",
         flex: 1,
         justifyContent: "center",
+    },
+    requestAuthorizationContainer: {
+        alignItems: "center",
+        backgroundColor: lightPeach,
+        borderRadius: 30,
+        height: "50%",
+        justifyContent: "center",
+        padding: 20,
+        width: "70%",
+    },
+    requestAuthorizationsButton: {
+        alignItems: "center",
+        borderColor: peach,
+        borderRadius: 20,
+        borderWidth: 2,
+        height: "20%",
+        justifyContent: "center",
+        marginVertical: "20%",
+        width: "70%",
     },
 
 })

--- a/screens/QrScan/styles.ts
+++ b/screens/QrScan/styles.ts
@@ -1,0 +1,11 @@
+import { StyleSheet } from "react-native" 
+
+export const styles = StyleSheet.create({
+    container: {
+        alignItems: "center",
+        flex: 1,
+        justifyContent: "center",
+    },
+
+})
+  


### PR DESCRIPTION
# What I did
I added a screen from which you can scan use the camera to scan QR codes. This screen will start by asking camera permissions if the app doesn't have them. We can discuss the UI because this screen wasn't in the Figma. Also note that there is a bit of latency when changing home screen. I tried my best to reduce it by changing screen before the camera mounts or unmounts but I think there is room for improvement.

# How I did it
- Added dependency `expo-camera` in `package.json`.
- Implemented the screen in `QrScanScreen.tsx` and added it to the navigation.
- Added adequate tests for the screen.

# How to verify it
You can **test the authorization button** when arriving on the connection screen (from home navigation). If the app does not ask for authorization, you can remove camera permissions in settings for expo go (without closing the app expo go) and relaunch uniconnect, this should make it ask you for permission. After testing permissions, you can **test the camera and try to scan a QR code** and see if the right alert pops. You can also run the tests.

# Demo video

https://github.com/uniconnect-epfl/uniconnect/assets/93329823/794f6cf7-f576-42e8-9b6a-1a5bebc6d6de

# Pre-merge checklist
The changes I have introduced:
- [x] work correctly
- [x] do not break other functionalities
- [x] work correctly on Android
- [x] are fully tested