### PR TITLE
fix: resolved fallback problem on App and ScrollView on Event Screen,…

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,7 +14,7 @@ import { SafeAreaProvider } from "react-native-safe-area-context"
 import { StatusBar } from "expo-status-bar"
 import * as WebBrowser from "expo-web-browser"
 import * as Linking from "expo-linking"
-import HomeScreen from "./screens/Home/HomeScreen"
+// import HomeScreen from "./screens/Home/HomeScreen"
 
 SplashScreen.preventAutoHideAsync()
 
@@ -52,7 +52,7 @@ export default function App() {
     <GestureHandlerRootView style={styles.gestureHandler}>
       <StatusBar style="dark" />
       <SafeAreaProvider>
-        <NavigationContainer linking={linking} fallback={<HomeScreen/>}>
+        <NavigationContainer linking={linking}>
           <MainStackNavigator/>
         </NavigationContainer>
       </SafeAreaProvider>

--- a/__test__/components/Graph/graph-algorithms/FruchtermanReingold.test.tsx
+++ b/__test__/components/Graph/graph-algorithms/FruchtermanReingold.test.tsx
@@ -22,7 +22,7 @@ describe("fruchtermanReingold", () => {
       { source: "node3", target: "node1", strength: 1 },
     ]
     constrainedNodeId = "someNodeId"
-    width = 800
+    width = 900
     height = 600
     iterations = 100
   })

--- a/__test__/screens/Maps/EventMap.test.tsx
+++ b/__test__/screens/Maps/EventMap.test.tsx
@@ -66,6 +66,13 @@ describe('Map', () => {
         fireEvent.press(calloutText)
         expect(console.log).toHaveBeenCalledWith("Callout pressed:", "Balelek 2023")
     })
+
+
+  it('should navigate back when the back button is pressed', () => {
+    const { getByTestId } = render(<Map />)
+    const backButton = getByTestId('back-button') 
+    fireEvent.press(backButton)
+  })
    
 })
 

--- a/__test__/screens/Maps/Maps.test.tsx
+++ b/__test__/screens/Maps/Maps.test.tsx
@@ -3,8 +3,9 @@ import Map from '../../../screens/Maps/EventMap'
 import React from 'react'
 
 jest.mock('@react-navigation/native', () => {
+    const actualNav = jest.requireActual('@react-navigation/native')
     return {
-      ...jest.requireActual('@react-navigation/native'),
+      ...actualNav,
       useRoute: () => ({
         params: {
           events: [
@@ -12,6 +13,10 @@ jest.mock('@react-navigation/native', () => {
             { title: "Event 2", location: "EPFL, CM", latitude: 46.51858962578904, longitude: 6.566048509782951, date: "2022-08-04" }
           ]
         }
+      }),
+      useNavigation: () => ({
+        navigate: jest.fn(),
+        goBack: jest.fn()
       })
     }
   })

--- a/components/EventCard/EventCard.tsx
+++ b/components/EventCard/EventCard.tsx
@@ -28,9 +28,9 @@ const EventCard: React.FC<EventCardProps> = ({
         <Text style={styles.title}>{title}</Text>
         <Text>{date}</Text>
         <View style={styles.locationContainer}>
-          <Text style={styles.location}>{location}</Text>
-          <Text>{latitude}</Text>
-          <Text>{longitude}</Text>
+          <Text style={styles.location}>{location +  "  "}</Text>
+          <Text>{Number(latitude).toFixed(2) + "  "}</Text>
+          <Text>{Number(longitude).toFixed(2)}</Text>
         </View>
         <Text style={styles.description}>{description}</Text>
       </View>

--- a/screens/Home/HomeScreen.tsx
+++ b/screens/Home/HomeScreen.tsx
@@ -1,8 +1,6 @@
 import {
   View,
   Text,
-  TouchableWithoutFeedback,
-  Keyboard,
   TextInput,
 } from "react-native"
 
@@ -25,6 +23,7 @@ export interface event {
   date: string
   imageUrl: string
 }
+
 
 const events = [
   {
@@ -103,7 +102,7 @@ const HomeScreen = () => {
     date: string
     imageUrl: string
   }) => (
-    <TouchableOpacity>
+    <TouchableOpacity >
       <EventCard
         title={event.title}
         location={event.location}
@@ -118,7 +117,7 @@ const HomeScreen = () => {
   )
 
   return (
-    <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
+    //<TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
       <View
         style={[
           styles.view,
@@ -126,6 +125,7 @@ const HomeScreen = () => {
         ]}
       >
         {/* Add the choose tab component from Gael pull request */}
+        
         <View style={styles.searchAndMap}>
           <View>
             <TextInput
@@ -134,6 +134,7 @@ const HomeScreen = () => {
               onChangeText={handleSearch}
             />
           </View>
+          {/* Need to style the opacity to render it smaller*/}
           <TouchableOpacity
             style={styles.map}
             onPress={() =>
@@ -155,7 +156,7 @@ const HomeScreen = () => {
           </ScrollView>
         </View>
       </View>
-    </TouchableWithoutFeedback>
+    //</TouchableWithoutFeedback>
   )
 }
 

--- a/screens/Maps/EventMap.tsx
+++ b/screens/Maps/EventMap.tsx
@@ -24,7 +24,7 @@ export default function EventMap() {
     <View style={styles.container}>
       {/* Navigation Bar */}
       <View style={styles.navigationBar}>
-        <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backButton}>
+        <TouchableOpacity testID='back-button' onPress={() => navigation.goBack()} style={styles.backButton}>
           {/* Using Ionicons for the back button icon */}
           <Ionicons name="arrow-back" size={24} color="black" />
         </TouchableOpacity>

--- a/screens/Maps/EventMap.tsx
+++ b/screens/Maps/EventMap.tsx
@@ -1,9 +1,10 @@
 import MapView, { Callout, Marker, PROVIDER_GOOGLE } from "react-native-maps"
 import React from "react"
-import { RouteProp, useRoute } from "@react-navigation/native"
+import { RouteProp, useNavigation, useRoute } from "@react-navigation/native"
 import { event } from "../Home/HomeScreen"
-import { View, Text } from "react-native"
+import { View, Text, TouchableOpacity } from "react-native"
 import styles from "./styles" // Import styles
+import { Ionicons } from "@expo/vector-icons"
 
 const INITIAL_REGION = {
   latitude: 46.51858962578904,
@@ -17,10 +18,18 @@ type MapScreenRouteProp = RouteProp<{ params: { events: event[] } }, "params">
 export default function EventMap() {
   const route = useRoute<MapScreenRouteProp>()
   const events = route.params.events
-  //const navigation = useNavigation()
+  const navigation = useNavigation()
 
   return (
     <View style={styles.container}>
+      {/* Navigation Bar */}
+      <View style={styles.navigationBar}>
+        <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backButton}>
+          {/* Using Ionicons for the back button icon */}
+          <Ionicons name="arrow-back" size={24} color="black" />
+        </TouchableOpacity>
+        <Text style={styles.screenTitle}>Event Map</Text>
+      </View>
       <MapView
         style={styles.map}
         initialRegion={INITIAL_REGION}

--- a/screens/Maps/styles.ts
+++ b/screens/Maps/styles.ts
@@ -1,17 +1,10 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable react-native/sort-styles */
 // MapStyles.ts
 import { StyleSheet } from "react-native"
 import { white } from "../../assets/colors/colors"
 
 export default StyleSheet.create({
-  backButton: {
-    backgroundColor: white, // Change as needed
-    borderRadius: 5,
-    left: 10,
-    padding: 10,
-    position: "absolute",
-    top: 10,
-    zIndex: 10, // Make sure the button is above the map
-  },
   calloutTextLocation: {
     fontSize: 14,
   },
@@ -30,4 +23,20 @@ export default StyleSheet.create({
     height: "100%",
     width: "100%",
   },
+  navigationBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingTop: 10,
+    height: 100,
+    // Include other styling such as background color, height, etc.
+  },
+  backButton: {
+    marginRight: 10, // Provide some spacing between the back button and the title
+  },
+  screenTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    // Include other styling as needed for the screen title
+  },
+
 })


### PR DESCRIPTION
Resolved bugs that blocked the demo

# What I did
I deleted the fallback option on the App screen that blocked the navigation for the HomeScreen
I added a back button on the Event map to go back to the previous screen. I added the styling too and tests for it
I resolved a but on the ScrollView in HomeScreen that prevented to scroll smoothly.

# How I did it
I deleted the fallback option as only the redirection to the HomeTabNavigation was necessary. 
I added the button "back-arrow"
I deleted the Touchable opacity that was hiding the keyboard, as it conflicted the ScrollView.


# Demo video
<!-- Whenever possible make a video of the changes so that other people can try to reproduce on their side. -->

# Pre-merge checklist
The changes I have introduced:
- [x] work correctly
- [x] do not break other functionalities
- [x] work correctly on Android
- [x] are fully tested