### PR TITLE
feat: initial event creation page

### DIFF
--- a/__test__/screens/EventCreation/EventCreationScreeen.test.tsx
+++ b/__test__/screens/EventCreation/EventCreationScreeen.test.tsx
@@ -1,0 +1,57 @@
+import React from "react"
+import { fireEvent, render } from "@testing-library/react-native"
+import EventCreationScreen from "../../../screens/EventCreation/EventCreationScreen"
+
+const mockGoBack = jest.fn()
+
+jest.mock("@react-navigation/native", () => {
+  return {
+    ...jest.requireActual("@react-navigation/native"),
+    useNavigation: () => ({
+      goBack: mockGoBack,
+    }),
+  }
+})
+
+// Component import
+
+describe("EventCreationScreen", () => {
+  it("renders correctly", () => {
+    const { getByText, getByPlaceholderText } = render(<EventCreationScreen />)
+    expect(getByText("Announcement")).toBeTruthy()
+    expect(getByPlaceholderText("Title")).toBeTruthy()
+  })
+
+  it("allows toggling between event and announcement", () => {
+    const { getByText } = render(<EventCreationScreen />)
+    const toggleButton = getByText("Announcement")
+    fireEvent.press(toggleButton)
+    expect(getByText("Event")).toBeTruthy()
+    fireEvent.press(toggleButton)
+    expect(getByText("Announcement")).toBeTruthy()
+  })
+
+  it("shows date input fields when event is selected", () => {
+    const { getByText, queryByPlaceholderText } = render(
+      <EventCreationScreen />
+    )
+    expect(queryByPlaceholderText("Start Date")).toBeNull()
+    fireEvent.press(getByText("Announcement"))
+    expect(queryByPlaceholderText("Start Date")).toBeTruthy()
+    expect(queryByPlaceholderText("End Date")).toBeTruthy()
+  })
+
+  it('should handle "Add a description" button press', () => {
+    const { getByText } = render(<EventCreationScreen />)
+    const descriptionButton = getByText("Add a description")
+    fireEvent.press(descriptionButton)
+    // You can expand this to check if a specific function is called or a modal/dialog opens
+  })
+
+  it('should handle "Validate" button press', () => {
+    const { getByText } = render(<EventCreationScreen />)
+    const validateButton = getByText("Validate")
+    fireEvent.press(validateButton)
+    // You can expand this to check if a specific function is called or if navigation occurs
+  })
+})

--- a/__test__/screens/Settings/SettingsScreen.test.tsx
+++ b/__test__/screens/Settings/SettingsScreen.test.tsx
@@ -44,7 +44,7 @@ describe("SettingsScreen", () => {
 
     // Assert that the menu items are rendered
     const menuItemTexts = [
-      "ACCOUNT CENTER",
+      "CREATE EVENT",
       "LANGUAGE",
       "NOTIFICATIONS",
       "HELP",
@@ -77,7 +77,7 @@ describe("SettingsScreen", () => {
       </NavigationContainer>
     )
 
-    const menuItem = getByText("ACCOUNT CENTER")
+    const menuItem = getByText("LANGUAGE")
     fireEvent.press(menuItem)
 
     expect(alertSpy).toHaveBeenCalledWith("Coming soon")

--- a/navigation/Main/MainStackNavigator.tsx
+++ b/navigation/Main/MainStackNavigator.tsx
@@ -11,6 +11,7 @@ import { MyQrCodeScreen } from "../../screens/Profile/MyQrCode/MyQrCodeScreen"
 import { UpdateMyProfileScreen } from "../../screens/Profile/UpdateMyProfile/UpdateMyProfileScreen"
 import ExternalProfileScreen from "../../screens/Profile/ExternalProfileScreen/ExternalProfileScreen"
 import DescriptionScreen from "../../screens/Registration/DescriptionScreen/DescriptionScreen"
+import EventCreationScreen from "../../screens/EventCreation/EventCreationScreen"
 import { auth } from "../../firebase/firebaseConfig"
 import { User, onAuthStateChanged } from "firebase/auth"
 import LoadingScreen from "../../screens/Loading/LoadingScreen"
@@ -88,7 +89,7 @@ const MainStackNavigator: React.FC = () => {
     >
       <Stack.Navigator
         initialRouteName={
-          user ? (fillOutProfile ? "UpdateProfile" : "HomeTabs") : "Onboarding"
+          user ? (fillOutProfile ? "EventCreation" : "HomeTabs") : "Onboarding"
         }
       >
         {user ? (
@@ -132,6 +133,11 @@ const MainStackNavigator: React.FC = () => {
             <Stack.Screen
               name="AddContact"
               component={AddContactScreen}
+              options={{ headerShown: false }}
+            />
+            <Stack.Screen
+              name="EventCreation"
+              component={EventCreationScreen}
               options={{ headerShown: false }}
             />
           </>

--- a/navigation/Main/MainStackNavigator.tsx
+++ b/navigation/Main/MainStackNavigator.tsx
@@ -89,7 +89,7 @@ const MainStackNavigator: React.FC = () => {
     >
       <Stack.Navigator
         initialRouteName={
-          user ? (fillOutProfile ? "EventCreation" : "HomeTabs") : "Onboarding"
+          user ? (fillOutProfile ? "UpdateProfile" : "HomeTabs") : "Onboarding"
         }
       >
         {user ? (

--- a/screens/EventCreation/EventCreationScreen.tsx
+++ b/screens/EventCreation/EventCreationScreen.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from "react"
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+  Alert,
+} from "react-native"
+import { styles } from "./styles"
+import { useNavigation } from "@react-navigation/native"
+import { Ionicons } from "@expo/vector-icons"
+import { globalStyles } from "../../assets/global/globalStyles"
+import { peach, white } from "../../assets/colors/colors"
+
+const EventCreationScreen = () => {
+  const navigation = useNavigation()
+  const [isEvent, setIsEvent] = useState(false)
+
+  return (
+    <ScrollView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          testID="back-button"
+        >
+          <Ionicons name="arrow-back-outline" size={24} color={peach} />
+        </TouchableOpacity>
+        <View style={styles.headerIcon}>
+          <Ionicons name="add" size={24} color={peach} />
+        </View>
+      </View>
+      <View style={styles.body}>
+        <View
+          style={
+            isEvent
+              ? [styles.toggleBase, styles.toggleEvent ]
+              : [styles.toggleBase, styles.toggleAnnouncement]
+          }
+        >
+          <TouchableOpacity
+            onPress={() => setIsEvent(!isEvent)}
+          >
+            <Text style={isEvent ? styles.toggleTextEvent : styles.toggleTextAnnouncement}>
+              {isEvent ? "Event" : "Announcement"}
+            </Text>
+          </TouchableOpacity>
+        </View>
+        <View style={styles.form}>
+          <View style={styles.tagsSepator}>
+            <TextInput style={[styles.input, globalStyles.text]} placeholder="Title" />
+            <Text style={[styles.tagsTitle, globalStyles.text]}>Choose up to three tags</Text>
+            <View style={styles.tags}>
+              <View style={styles.addTag}>
+                <Ionicons name="add" size={24} color={white} />
+              </View>
+              <View style={styles.addTag}>
+                <Ionicons name="add" size={24} color={white} />
+              </View>
+              <View style={styles.addTag}>
+                <Ionicons name="add" size={24} color={white} />
+              </View>
+            </View>
+          </View>
+          {isEvent && (
+            <>
+              <View style={styles.dateContainer}>
+                <TextInput style={[styles.input, globalStyles.text]} placeholder="Start Date" />
+                <TextInput style={[styles.input, globalStyles.text]} placeholder="End Date" />
+              </View>
+              <TextInput style={[styles.input, globalStyles.text]} placeholder="Location" />
+            </>
+          )}
+          <View style={styles.bottomButtons}>
+          <TouchableOpacity style={[styles.buttonBase, styles.buttonDescription]}>
+            <Text onPress={() => Alert.alert("SOON^TM")} style={globalStyles.boldText}>Add a description</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={[styles.buttonBase, styles.buttonValidate]}>
+            <Text onPress={() => Alert.alert("SOON^TM")} style={globalStyles.boldText}>Validate</Text>
+          </TouchableOpacity>
+        </View>
+        </View>
+      </View>
+    </ScrollView>
+  )
+}
+
+export default EventCreationScreen

--- a/screens/EventCreation/styles.ts
+++ b/screens/EventCreation/styles.ts
@@ -1,0 +1,119 @@
+import { StyleSheet } from "react-native"
+import { black, lightPeach, peach, shadowColor, white } from "../../assets/colors/colors"
+
+export const styles = StyleSheet.create({
+  activeButton: {
+    backgroundColor: peach,
+    color: white,
+  },
+  activeText: {
+    color: white,
+  },
+  addTag: {
+    alignItems: "center",
+    backgroundColor: peach,
+    borderRadius: 50,
+    color: white,
+    padding: 5,
+    shadowColor,
+    width: 100,
+ },
+  body: {
+    padding: 20
+  },
+  bottomButtons: {
+    alignItems: "center",
+    justifyContent: "flex-end",
+    padding: 20,
+  },
+  button: {
+    alignItems: "center",
+    backgroundColor: peach,
+    padding: 10,
+  },
+  buttonBase: {
+    alignItems: "center",
+    backgroundColor: lightPeach,
+    borderColor: peach,
+    borderRadius: 20,
+    borderWidth: 2,
+    display: "flex",
+    elevation: 8,
+    height: 30,
+    justifyContent: "center",
+    shadowColor,
+    shadowOffset: { width: 0, height: 2.5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 5,
+    width: "30%",
+  },
+ buttonDescription: {
+  },
+  buttonText: {
+    color: black,
+  },
+  buttonValidate: {
+  },
+  container: { 
+    backgroundColor: white,
+    flex: 1,
+  },
+  dateContainer: {
+    flexDirection: "row",
+    justifyContent: "space-evenly",
+    paddingTop: 50,
+  },
+  form: {
+    flex: 1,
+  },
+  header: {
+    alignItems: "center",
+    backgroundColor: lightPeach,
+    flexDirection: "row",
+    paddingHorizontal: 20,
+    paddingVertical: 40,
+  },
+ headerIcon: {
+    alignItems: "center",
+    flex: 1,
+  },
+  input: {
+    borderColor: lightPeach,
+    borderWidth: 1,
+    marginBottom: 10,
+    padding: 10,
+  },
+  tags: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginBottom: 10,
+  },
+  tagsSepator: {
+    borderBottomColor: black,
+    borderBottomWidth: 1,
+    paddingBottom: 20,
+ },
+  tagsTitle: {
+    color: black,
+    marginBottom: 10,
+ },
+  toggleAnnouncement: {
+    backgroundColor: peach,
+  },
+  toggleBase: {
+
+    alignItems: "center",
+    borderRadius: 20,
+    marginBottom: 20,
+    padding: 10,
+  },
+  toggleEvent: {
+    backgroundColor: lightPeach,
+  },
+  toggleTextAnnouncement: {
+    color: lightPeach,
+  },
+  toggleTextEvent: {
+    color: peach,
+  }
+})

--- a/screens/Settings/SettingsScreen.tsx
+++ b/screens/Settings/SettingsScreen.tsx
@@ -1,3 +1,4 @@
+import React from "react"
 import { View, Text, TouchableOpacity, Alert  } from "react-native"
 import { styles } from "./styles"
 import { useNavigation } from "@react-navigation/native"
@@ -16,7 +17,7 @@ export const SettingsScreen = () => {
   const pressPlaceholder = () => Alert.alert("Coming soon")
 
   const menuItems: MenuItem[] = [
-    { title: "ACCOUNT CENTER", action: pressPlaceholder },
+    { title: "CREATE EVENT", action: () => navigation.navigate("EventCreation" as never) },
     { title: "LANGUAGE",  action: pressPlaceholder },
     { title: "NOTIFICATIONS", action: pressPlaceholder },
     { title: "HELP",  action: pressPlaceholder },


### PR DESCRIPTION
# What I did
<!-- Example: I implemented the login functionality with google... -->
Implemented a state-less event creation screen to connect to the database.

# How I did it
<!-- Example:
- I added a new screen in which there's a button to login. You can access the screen by...
- To make the login work I installed a new `google-auth` and connected it with firebase... -->
- Created a new screen, connected to the `Stack.Navigator` for logged in users and created some basic styling.

# How to verify it
<!-- Example: 
- 1. Interact with this button
- 2. Long press to obtain help
- 3. etc... -->
1. Login
2. Go to settings screen
3. Click on create event
4. Try the page out as in the demo

# Demo video
https://github.com/uniconnect-epfl/uniconnect/assets/11707683/f1d7ce0c-d1ba-413f-9874-60be0921d768


# Pre-merge checklist
The changes I have introduced:
- [x] work correctly
- [x] do not break other functionalities
- [x] work correctly on Android
- [x] are fully tested