### PR TITLE
ci: now build is triggered only on release

### DIFF
--- a/.github/workflows/eas.yml
+++ b/.github/workflows/eas.yml
@@ -1,10 +1,10 @@
 name: EAS 
 
 on:
+  release:
+    types: [created]
   workflow_dispatch:
-  push:
-    branches:
-      - main
+
 jobs:
   build:
     name: Install and build


### PR DESCRIPTION
# What I did
Now continuous integrations only build on release or on dispatch workflow. This change was necessary as we were regularly running out of free builds.

# How to verify it
Click on the button to trigger a manual workflow. Try to do a release (and delete it after please).