### PR TITLE
feat: choose point on map for events

### DIFF
--- a/__test__/screens/EventCreation/EventCreationScreeen.test.tsx
+++ b/__test__/screens/EventCreation/EventCreationScreeen.test.tsx
@@ -154,6 +154,6 @@ describe("EventCreationScreen", () => {
       <EventCreationScreen isAnnouncement={true} navigation={mockNavigation} />
     )
     rerender(<EventCreationScreen isAnnouncement={false} navigation={mockNavigation} />)
-    expect(queryByText("Add a location")).toBeTruthy()
+    expect(queryByText("Add a location")).toBeFalsy()
   })
 })

--- a/__test__/screens/EventCreation/EventCreationScreeen.test.tsx
+++ b/__test__/screens/EventCreation/EventCreationScreeen.test.tsx
@@ -155,6 +155,11 @@ describe("EventCreationScreen", () => {
     )
     rerender(<EventCreationScreen isAnnouncement={false} navigation={mockNavigation} />)
     expect(queryByText("Add a location")).toBeFalsy()
-    fireEvent.press(queryByText("Add a location"))
   })
+
+  it("can add locations", () => {
+    const { getByText } = render(<EventCreationScreen navigation={mockNavigation} />)
+    fireEvent.press(getByText("Modify location"))
+  })
+
 })

--- a/__test__/screens/EventCreation/EventCreationScreeen.test.tsx
+++ b/__test__/screens/EventCreation/EventCreationScreeen.test.tsx
@@ -154,12 +154,12 @@ describe("EventCreationScreen", () => {
       <EventCreationScreen isAnnouncement={true} navigation={mockNavigation} />
     )
     rerender(<EventCreationScreen isAnnouncement={false} navigation={mockNavigation} />)
-    expect(queryByText("Add a location")).toBeFalsy()
+    expect(queryByText("Add a location")).toBeTruthy()
   })
 
   it("can add locations", () => {
     const { getByText } = render(<EventCreationScreen navigation={mockNavigation} />)
-    fireEvent.press(getByText("Modify location"))
+    fireEvent.press(getByText("Add a location"))
   })
 
 })

--- a/__test__/screens/EventCreation/EventCreationScreeen.test.tsx
+++ b/__test__/screens/EventCreation/EventCreationScreeen.test.tsx
@@ -155,5 +155,6 @@ describe("EventCreationScreen", () => {
     )
     rerender(<EventCreationScreen isAnnouncement={false} navigation={mockNavigation} />)
     expect(queryByText("Add a location")).toBeFalsy()
+    fireEvent.press(queryByText("Add a location"))
   })
 })

--- a/__test__/screens/SelectLocation/SelectLocationScreen.test.tsx
+++ b/__test__/screens/SelectLocation/SelectLocationScreen.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { fireEvent, render } from '@testing-library/react-native'
+import { SelectLocationScreen } from '../../../screens/SelectLocation/SelectLocationScreen'
+import { NavigationContainer } from '@react-navigation/native'
+
+const mockGoBack = jest.fn()
+const mockNavigate = jest.fn()
+
+jest.mock("@react-navigation/native", () => {
+    return {
+      ...jest.requireActual("@react-navigation/native"),
+      useRoute: () => ({
+        params: {
+          initialLocation: {x: 0, y: 0},
+          onLocationChange: jest.fn()
+        },
+      }),
+      useNavigation: () => ({
+        navigate: mockNavigate,
+        goBack: mockGoBack,
+      }),
+    }
+  })
+
+//mock an alert with jest
+global.alert = jest.fn()
+
+
+describe('SelectLocationScreen', () => {
+  
+  it('renders correctly', () => {
+    const component = render(
+        <NavigationContainer>
+            <SelectLocationScreen />
+        </NavigationContainer>
+    )
+    expect(component).toBeTruthy()
+  })
+
+  it('renders correctly', () => {
+    const { getByText } = render(
+        <NavigationContainer>
+            <SelectLocationScreen />
+        </NavigationContainer>
+    )
+    const confirmButton = getByText("Confirm")
+    fireEvent.press(confirmButton)
+    expect(mockGoBack).toHaveBeenCalled
+  })
+  
+})

--- a/__test__/screens/SelectLocation/SelectLocationScreen.test.tsx
+++ b/__test__/screens/SelectLocation/SelectLocationScreen.test.tsx
@@ -62,13 +62,15 @@ describe('SelectLocationScreen', () => {
           goBack: mockGoBack,
         }),
       }
-  })
-    const component = render(
+    })
+    const { getByText } = render(
         <NavigationContainer>
             <SelectLocationScreen />
         </NavigationContainer>
     )
-    expect(component).toBeTruthy()
+    const confirmButton = getByText("Confirm")
+    fireEvent.press(confirmButton)
+    expect(mockGoBack).toHaveBeenCalled
     jest.resetAllMocks()
   })
 

--- a/__test__/screens/SelectLocation/SelectLocationScreen.test.tsx
+++ b/__test__/screens/SelectLocation/SelectLocationScreen.test.tsx
@@ -20,14 +20,23 @@ jest.mock("@react-navigation/native", () => {
         goBack: mockGoBack,
       }),
     }
-  })
+})
 
 //mock an alert with jest
 global.alert = jest.fn()
 
+jest.mock('react-native-maps', () => {
+    return {
+      __esModule: true,
+      default: jest.fn().mockImplementation(({ children, ...rest }) => <div {...rest}>{children}</div>), // Mocking MapView
+      Marker: jest.fn().mockImplementation(({ children, ...rest }) => <div {...rest}>{children}</div>), // Mocking Marker
+      Callout: jest.fn().mockImplementation(({ children, ...rest }) => <div {...rest}>{children}</div>), // Mocking Callout
+      PROVIDER_GOOGLE: 'google',
+    }
+  })
+
 
 describe('SelectLocationScreen', () => {
-  
   it('renders correctly', () => {
     const component = render(
         <NavigationContainer>
@@ -37,7 +46,32 @@ describe('SelectLocationScreen', () => {
     expect(component).toBeTruthy()
   })
 
-  it('renders correctly', () => {
+  it('renders correctly with no initial point', () => {
+    jest.mock("@react-navigation/native", () => {
+        const actualNav = jest.requireActual("@react-navigation/native")
+        return {
+          ...actualNav,
+          useRoute: () => ({
+            params: {
+              initialLocation: undefined,
+              onLocationChange: jest.fn()
+            },
+          }),
+          useNavigation: () => ({
+            navigate: jest.fn(),
+            goBack: jest.fn(),
+          }),
+        }
+      })
+    const component = render(
+        <NavigationContainer>
+            <SelectLocationScreen />
+        </NavigationContainer>
+    )
+    expect(component).toBeTruthy()
+  })
+
+  it('we can confirmate', () => {
     const { getByText } = render(
         <NavigationContainer>
             <SelectLocationScreen />
@@ -47,5 +81,5 @@ describe('SelectLocationScreen', () => {
     fireEvent.press(confirmButton)
     expect(mockGoBack).toHaveBeenCalled
   })
-  
+
 })

--- a/__test__/screens/SelectLocation/SelectLocationScreen.test.tsx
+++ b/__test__/screens/SelectLocation/SelectLocationScreen.test.tsx
@@ -47,28 +47,29 @@ describe('SelectLocationScreen', () => {
   })
 
   it('renders correctly with no initial point', () => {
+    jest.resetAllMocks()
     jest.mock("@react-navigation/native", () => {
-        const actualNav = jest.requireActual("@react-navigation/native")
-        return {
-          ...actualNav,
-          useRoute: () => ({
-            params: {
-              initialLocation: undefined,
-              onLocationChange: jest.fn()
-            },
-          }),
-          useNavigation: () => ({
-            navigate: jest.fn(),
-            goBack: jest.fn(),
-          }),
-        }
-      })
+      return {
+        ...jest.requireActual("@react-navigation/native"),
+        useRoute: () => ({
+          params: {
+            initialLocation: undefined,
+            onLocationChange: jest.fn()
+          },
+        }),
+        useNavigation: () => ({
+          navigate: mockNavigate,
+          goBack: mockGoBack,
+        }),
+      }
+  })
     const component = render(
         <NavigationContainer>
             <SelectLocationScreen />
         </NavigationContainer>
     )
     expect(component).toBeTruthy()
+    jest.resetAllMocks()
   })
 
   it('we can confirmate', () => {

--- a/navigation/Main/MainStackNavigator.tsx
+++ b/navigation/Main/MainStackNavigator.tsx
@@ -21,6 +21,7 @@ import { RegistrationContext } from "../../contexts/RegistrationContext"
 import EventScreen from "../../screens/Home/EventScreen/EventScreen"
 import ViewEventScreen from "../../screens/ViewDetails/ViewEventScreen/ViewEventScreen"
 import ViewAnnoucementScreen from "../../screens/ViewDetails/ViewAnnouncementScreen/ViewAnnouncementScreen"
+import { SelectLocationScreen } from "../../screens/SelectLocation/SelectLocationScreen"
 
 const Stack = createStackNavigator()
 
@@ -160,6 +161,11 @@ const MainStackNavigator: React.FC = () => {
             <Stack.Screen
               name="ViewAnnouncement"
               component={ViewAnnoucementScreen}
+              options={{ headerShown: false }}
+            />
+            <Stack.Screen
+              name="SelectLocation"
+              component={SelectLocationScreen}
               options={{ headerShown: false }}
             />
           </>

--- a/screens/EventCreation/EventCreationScreen.tsx
+++ b/screens/EventCreation/EventCreationScreen.tsx
@@ -47,14 +47,10 @@ const EventCreationScreen = ({ navigation, isAnnouncement }: EventCreationScreen
     console.log("Date:", date.toDateString())
     console.log("Interests:", interests)
 
-    if(point === undefined){
-      showErrorToast("An event needs a location!")
+    if (isAnnouncement) {
+      newAnnouncement()
     } else {
-      if (isAnnouncement) {
-        newAnnouncement()
-      } else {
-        newEvent()
-      }
+      newEvent()
     }
 
     // after the user has filled out the form
@@ -146,7 +142,7 @@ const EventCreationScreen = ({ navigation, isAnnouncement }: EventCreationScreen
               value={location}
               onChangeText={setLocation}
             />
-            
+
             <Pressable
               style={styles.section}
               onPress={() => {

--- a/screens/EventCreation/EventCreationScreen.tsx
+++ b/screens/EventCreation/EventCreationScreen.tsx
@@ -171,7 +171,6 @@ const EventCreationScreen = ({ navigation, isAnnouncement }: EventCreationScreen
           <Pressable style={styles.buttonBase}>
             <Text
               onPress={() => {
-                console.log("going to select a location")
                 navigation.navigate("SelectLocation", {onLocationChange: setPoint, initialPoint: point})
               }}
               style={globalStyles.boldText}

--- a/screens/EventCreation/EventCreationScreen.tsx
+++ b/screens/EventCreation/EventCreationScreen.tsx
@@ -27,6 +27,7 @@ const EventCreationScreen = ({ navigation, isAnnouncement }: EventCreationScreen
   const [date, setDate] = useState<Date>(new Date())
   const [hasBeenTouched, setHasBeenTouched] = useState(false)
   const [title, setTitle] = useState("")
+  const [location, setLocation] = useState("")
   const [point, setPoint] = useState<Point | undefined>(undefined)
   const insets = useSafeAreaInsets()
   const [interests] = useState(["Machine Learning, Sports, Tractoupelle"])
@@ -138,6 +139,13 @@ const EventCreationScreen = ({ navigation, isAnnouncement }: EventCreationScreen
                 setDateModal={setDateModal}
               />
             )}
+            
+            <InputField
+              label="Location*"
+              placeholder="Turing Avenue 69"
+              value={location}
+              onChangeText={setLocation}
+            />
             
             <Pressable
               style={styles.section}

--- a/screens/EventCreation/EventCreationScreen.tsx
+++ b/screens/EventCreation/EventCreationScreen.tsx
@@ -138,10 +138,14 @@ const EventCreationScreen = ({ navigation, isAnnouncement }: EventCreationScreen
         <View style={styles.bottomButtons}>
           <Pressable style={styles.buttonBase}>
             <Text
-              onPress={() => navigation.navigate("SelectLocation", {onLocationChange: setPoint, initialPoint: point})}
+              onPress={() => {
+                console.log("going to select a location")
+                console.log("location is " + point === undefined ? "undefined" : "defined")
+                navigation.navigate("SelectLocation", {onLocationChange: setPoint, initialPoint: point})
+              }}
               style={globalStyles.boldText}
               >
-              {point === null ? "Add a location" : "Modify location"}
+              {point === undefined ? "Add a location" : "Modify location"}
             </Text>
           </Pressable>
           <Pressable style={styles.buttonBase}>

--- a/screens/EventCreation/EventCreationScreen.tsx
+++ b/screens/EventCreation/EventCreationScreen.tsx
@@ -140,7 +140,6 @@ const EventCreationScreen = ({ navigation, isAnnouncement }: EventCreationScreen
             <Text
               onPress={() => {
                 console.log("going to select a location")
-                console.log("location is " + point === undefined ? "undefined" : "defined")
                 navigation.navigate("SelectLocation", {onLocationChange: setPoint, initialPoint: point})
               }}
               style={globalStyles.boldText}

--- a/screens/EventCreation/EventCreationScreen.tsx
+++ b/screens/EventCreation/EventCreationScreen.tsx
@@ -25,7 +25,7 @@ const EventCreationScreen = ({ navigation, isAnnouncement }: EventCreationScreen
   const [hasBeenTouched, setHasBeenTouched] = useState(false)
 
   const [title, setTitle] = useState("")
-  const [point, setPoint] = useState<Point | null>(null)
+  const [point, setPoint] = useState<Point | undefined>(undefined)
   const insets = useSafeAreaInsets()
   const [interests] = useState(["Machine Learning, Sports, Tractoupelle"])
 
@@ -34,16 +34,9 @@ const EventCreationScreen = ({ navigation, isAnnouncement }: EventCreationScreen
   const opacity = !hasBeenTouched ? 0.2 : 1
 
   const publish = async () => {
-    if(point === null){
+    if(point === undefined){
       showErrorToast("An event needs a location!")
     } else {
-      // send the data to the backend
-      console.log("Publishing event...")
-      console.log("Title:", title)
-      console.log("Description:", description)
-      console.log("Date:", date.toDateString())
-      console.log("Interests:", interests)
-
       if (isAnnouncement) {
         await createAnnouncement(
           "0",

--- a/screens/SelectLocation/SelectLocationScreen.tsx
+++ b/screens/SelectLocation/SelectLocationScreen.tsx
@@ -66,6 +66,7 @@ export const SelectLocationScreen = () => {
             style={styles.confirmButton}
             onPress={() => {
                 navigation.goBack()
+                console.log("user clicked on confirmate")
                 console.log("confirmating location")
                 console.log("we ve confirmated the location")
                 console.log("the location was entered we are now returning")

--- a/screens/SelectLocation/SelectLocationScreen.tsx
+++ b/screens/SelectLocation/SelectLocationScreen.tsx
@@ -66,14 +66,6 @@ export const SelectLocationScreen = () => {
             style={styles.confirmButton}
             onPress={() => {
                 navigation.goBack()
-                console.log("user clicked on confirmate")
-                console.log("confirmating location")
-                console.log("we ve confirmated the location")
-                console.log("the location was entered we are now returning")
-                console.log("is location defined ?")
-                console.log("we don't know yet")
-                console.log("we can now return")
-                console.log("going back to precedent screen")
             }}>
             <Text style={globalStyles.boldText}> 
                 Confirm 

--- a/screens/SelectLocation/SelectLocationScreen.tsx
+++ b/screens/SelectLocation/SelectLocationScreen.tsx
@@ -1,46 +1,71 @@
 import React, { View, Text, TouchableOpacity } from "react-native"
 import { styles } from "./styles"
 import { RouteProp, useNavigation, useRoute } from "@react-navigation/native"
-import MapView, { Marker, Point } from "react-native-maps"
+import MapView, { Marker, PROVIDER_GOOGLE, Point, Region } from "react-native-maps"
 import { useEffect, useState } from "react"
+import { globalStyles } from "../../assets/global/globalStyles"
 
 type RootStackParamList = {
     SelectLocationScreen: {
-        onLocationChange: (point: Point) => void,
+        initialPoint: Point | null,
+        onLocationChange: (point: Point | null) => void,
     }
 }
   
 type SelectLocationScreenRouteProps = RouteProp<RootStackParamList, "SelectLocationScreen">
 
 export const SelectLocationScreen = () => {
-    const { onLocationChange } = useRoute<SelectLocationScreenRouteProps>().params
+    const { onLocationChange, initialPoint } = useRoute<SelectLocationScreenRouteProps>().params
     const navigation = useNavigation()
-    const [region, setRegion] = useState({
-        latitude: 37.78825,
-        longitude: -122.4324,
-        latitudeDelta: 0.0922,
-        longitudeDelta: 0.0421,
-    })
+    const [location, setLocation] = useState<Point | null>(initialPoint)
+
+    const initialRegion: Region = {
+        latitude: initialPoint ? initialPoint.x : 46.51858962578904,
+        longitude: initialPoint ? initialPoint.y : 6.566048509782951,
+        latitudeDelta: 0.01,
+        longitudeDelta: 0.01,
+    }
 
     useEffect(() => {
-        onLocationChange({x: region.latitude, y: region.longitude})
-    }, [onLocationChange, region])
+        onLocationChange(location)
+    }, [onLocationChange, location])
 
 
     return (
       <View style={styles.container}>
+
+        <View style={styles.header}>
+            <Text style={[globalStyles.boldText, styles.screenTitle]}>
+                Select a location
+            </Text>
+        </View>   
+
         <MapView 
             style={styles.map} 
-            initialRegion={region} 
-            onRegionChangeComplete={setRegion}>
-            <Marker 
-                coordinate={region} 
-            />
+            initialRegion={initialRegion} 
+            showsUserLocation
+            showsMyLocationButton
+            provider={PROVIDER_GOOGLE}
+            onPress={(e) => {
+                const newLocation: Point = {x: e.nativeEvent.coordinate.latitude, y: e.nativeEvent.coordinate.longitude }
+                setLocation(newLocation)
+            }}
+            >
+            { location !== null && 
+                <Marker
+                    key={"location"} 
+                    coordinate={{
+                            latitude: location.x,
+                            longitude: location.y
+                        }}>
+
+                </Marker>
+            }
         </MapView>
         <TouchableOpacity
             style={styles.confirmButton}
             onPress={() => navigation.goBack()}>
-            <Text> 
+            <Text style={globalStyles.boldText}> 
                 Confirm 
             </Text>
         </TouchableOpacity>

--- a/screens/SelectLocation/SelectLocationScreen.tsx
+++ b/screens/SelectLocation/SelectLocationScreen.tsx
@@ -42,6 +42,7 @@ export const SelectLocationScreen = () => {
 
         <MapView 
             style={styles.map} 
+            testID="map"
             initialRegion={initialRegion} 
             showsUserLocation
             showsMyLocationButton

--- a/screens/SelectLocation/SelectLocationScreen.tsx
+++ b/screens/SelectLocation/SelectLocationScreen.tsx
@@ -27,6 +27,7 @@ export const SelectLocationScreen = () => {
     }
 
     useEffect(() => {
+        console.log("changed location")
         onLocationChange(location)
     }, [onLocationChange, location])
 

--- a/screens/SelectLocation/SelectLocationScreen.tsx
+++ b/screens/SelectLocation/SelectLocationScreen.tsx
@@ -70,7 +70,8 @@ export const SelectLocationScreen = () => {
                 console.log("confirmating location")
                 console.log("we ve confirmated the location")
                 console.log("the location was entered we are now returning")
-                console.log("location " + location ? "defined" : "undefined")
+                console.log("is location defined ?")
+                console.log("we don't know yet")
                 console.log("we can now return")
                 console.log("going back to precedent screen")
             }}>

--- a/screens/SelectLocation/SelectLocationScreen.tsx
+++ b/screens/SelectLocation/SelectLocationScreen.tsx
@@ -1,0 +1,49 @@
+import React, { View, Text, TouchableOpacity } from "react-native"
+import { styles } from "./styles"
+import { RouteProp, useNavigation, useRoute } from "@react-navigation/native"
+import MapView, { Marker, Point } from "react-native-maps"
+import { useEffect, useState } from "react"
+
+type RootStackParamList = {
+    SelectLocationScreen: {
+        onLocationChange: (point: Point) => void,
+    }
+}
+  
+type SelectLocationScreenRouteProps = RouteProp<RootStackParamList, "SelectLocationScreen">
+
+export const SelectLocationScreen = () => {
+    const { onLocationChange } = useRoute<SelectLocationScreenRouteProps>().params
+    const navigation = useNavigation()
+    const [region, setRegion] = useState({
+        latitude: 37.78825,
+        longitude: -122.4324,
+        latitudeDelta: 0.0922,
+        longitudeDelta: 0.0421,
+    })
+
+    useEffect(() => {
+        onLocationChange({x: region.latitude, y: region.longitude})
+    }, [onLocationChange, region])
+
+
+    return (
+      <View style={styles.container}>
+        <MapView 
+            style={styles.map} 
+            initialRegion={region} 
+            onRegionChangeComplete={setRegion}>
+            <Marker 
+                coordinate={region} 
+            />
+        </MapView>
+        <TouchableOpacity
+            style={styles.confirmButton}
+            onPress={() => navigation.goBack()}>
+            <Text> 
+                Confirm 
+            </Text>
+        </TouchableOpacity>
+      </View>
+    )
+}

--- a/screens/SelectLocation/SelectLocationScreen.tsx
+++ b/screens/SelectLocation/SelectLocationScreen.tsx
@@ -67,12 +67,11 @@ export const SelectLocationScreen = () => {
             onPress={() => {
                 navigation.goBack()
                 console.log("confirmating location")
-                if(location !== undefined){
-                    console.log("location x: " + location.x)
-                    console.log("location y: " + location.y)
-                }
+                console.log("we ve confirmated the location")
+                console.log("the location was entered we are now returning")
+                console.log("location " + location ? "defined" : "undefined")
+                console.log("we can now return")
                 console.log("going back to precedent screen")
-
             }}>
             <Text style={globalStyles.boldText}> 
                 Confirm 

--- a/screens/SelectLocation/SelectLocationScreen.tsx
+++ b/screens/SelectLocation/SelectLocationScreen.tsx
@@ -20,8 +20,8 @@ export const SelectLocationScreen = () => {
     const [location, setLocation] = useState<Point | undefined>(initialPoint)
 
     const initialRegion: Region = {
-        latitude: initialPoint ? initialPoint.x : 46.51858962578904,
-        longitude: initialPoint ? initialPoint.y : 6.566048509782951,
+        latitude: 46.51858962578904,
+        longitude: 6.566048509782951,
         latitudeDelta: 0.01,
         longitudeDelta: 0.01,
     }

--- a/screens/SelectLocation/SelectLocationScreen.tsx
+++ b/screens/SelectLocation/SelectLocationScreen.tsx
@@ -7,8 +7,8 @@ import { globalStyles } from "../../assets/global/globalStyles"
 
 type RootStackParamList = {
     SelectLocationScreen: {
-        initialPoint: Point | null,
-        onLocationChange: (point: Point | null) => void,
+        initialPoint: Point | undefined,
+        onLocationChange: (point: Point | undefined) => void,
     }
 }
   
@@ -17,7 +17,7 @@ type SelectLocationScreenRouteProps = RouteProp<RootStackParamList, "SelectLocat
 export const SelectLocationScreen = () => {
     const { onLocationChange, initialPoint } = useRoute<SelectLocationScreenRouteProps>().params
     const navigation = useNavigation()
-    const [location, setLocation] = useState<Point | null>(initialPoint)
+    const [location, setLocation] = useState<Point | undefined>(initialPoint)
 
     const initialRegion: Region = {
         latitude: initialPoint ? initialPoint.x : 46.51858962578904,
@@ -51,7 +51,7 @@ export const SelectLocationScreen = () => {
                 setLocation(newLocation)
             }}
             >
-            { location !== null && 
+            { location !== undefined && 
                 <Marker
                     key={"location"} 
                     coordinate={{

--- a/screens/SelectLocation/SelectLocationScreen.tsx
+++ b/screens/SelectLocation/SelectLocationScreen.tsx
@@ -27,7 +27,6 @@ export const SelectLocationScreen = () => {
     }
 
     useEffect(() => {
-        console.log("changed location")
         onLocationChange(location)
     }, [onLocationChange, location])
 
@@ -43,7 +42,6 @@ export const SelectLocationScreen = () => {
 
         <MapView 
             style={styles.map} 
-            testID="map"
             initialRegion={initialRegion} 
             showsUserLocation
             showsMyLocationButton
@@ -66,7 +64,16 @@ export const SelectLocationScreen = () => {
         </MapView>
         <TouchableOpacity
             style={styles.confirmButton}
-            onPress={() => navigation.goBack()}>
+            onPress={() => {
+                navigation.goBack()
+                console.log("confirmating location")
+                if(location !== undefined){
+                    console.log("location x: " + location.x)
+                    console.log("location y: " + location.y)
+                }
+                console.log("going back to precedent screen")
+
+            }}>
             <Text style={globalStyles.boldText}> 
                 Confirm 
             </Text>

--- a/screens/SelectLocation/styles.ts
+++ b/screens/SelectLocation/styles.ts
@@ -3,18 +3,35 @@ import { lightPeach, peach } from "../../assets/colors/colors"
 
 export const styles = StyleSheet.create({
     confirmButton: {
+        alignItems: "center",
         backgroundColor: lightPeach,
         borderColor: peach,
         borderRadius: 15,
         borderWidth: 2,
+        height: "6%",
+        justifyContent: "center",
+        margin: 15,
+        width: "40%",
     },
     container: {
         alignItems: "center",
         flex: 1,
         justifyContent: "center",
     }, 
-    map: {
-
+    header: {
+        alignItems: "center",
+        height: "10%",
+        justifyContent: "center",
+        width: "100%",
     },
+    map: {
+        flex: 1,
+        height: "100%",
+        width: "100%",
+    },
+    screenTitle: {
+        fontSize: 20,
+        paddingTop: "10%",
+    }
 
 })

--- a/screens/SelectLocation/styles.ts
+++ b/screens/SelectLocation/styles.ts
@@ -1,0 +1,20 @@
+import { StyleSheet } from "react-native"
+import { lightPeach, peach } from "../../assets/colors/colors"
+
+export const styles = StyleSheet.create({
+    confirmButton: {
+        backgroundColor: lightPeach,
+        borderColor: peach,
+        borderRadius: 15,
+        borderWidth: 2,
+    },
+    container: {
+        alignItems: "center",
+        flex: 1,
+        justifyContent: "center",
+    }, 
+    map: {
+
+    },
+
+})


### PR DESCRIPTION
# What I did
- Added a screen for the user to select a location on the map.
- Added a button that redirect to this screen in `EventCreationScreen`

# How I did it
- Created the `SelectLocationScreen` and added it to navigation. The screen manages it's own point state internally (meaning the currently selected location is managed internally) but when navigating you can give a call back function for when the date change, the same way as a TextInput.
- Used `react-native-maps` to implement the map.
- Added a button in `EventCreationScreen` that redirects to this screen with the right callback function.
- Modified tests to reflect changes.

# How to verify it
Launch the application in expo go:
- Go into `EventCreationScreen`
- Create a new event and add a location (Note that there is a warning but it will be fixed in another PR also fixing the warnings in the other maps)
- Try to click at multiples places (note that if you click on the name of a city for example the click does not register)
- Try to confirmate the location
- Go back to modify the location, see if it registered correctly
- Save the event
- You can go in the database and check if the location point is good

# Demo video

https://github.com/uniconnect-epfl/uniconnect/assets/93329823/afc0c2d8-a98b-443e-ab70-1c95c2b3e9a9

# Pre-merge checklist
The changes I have introduced:
- [x] work correctly
- [x] do not break other functionalities
- [x] work correctly on Android
- [x] are fully tested