### PR TITLE
fix: corrected minor bug in InterestsScreen

### DIFF
--- a/screens/Registration/InterestsScreen/InterestsScreen.tsx
+++ b/screens/Registration/InterestsScreen/InterestsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react"
+import React, { useState, useEffect, useContext, useCallback } from "react"
 import {
   View,
   Text,
@@ -20,6 +20,7 @@ import { fetchInterests, Interest } from "../../../firebase/Interests"
 import LoadingScreen from "../../Loading/LoadingScreen"
 import useKeyboardVisibility from "../../../hooks/useKeyboardVisibility"
 import { RegistrationContext } from "../../../contexts/RegistrationContext"
+import { useFocusEffect } from "@react-navigation/native"
 
 interface InterestButtonProps {
   interest: Interest
@@ -74,6 +75,14 @@ const InterestsScreen = () => {
         setIsLoading(false)
       })
   }, [])
+
+  useFocusEffect(
+    useCallback(() => {
+      setSelectedInterests([])
+      setLabelArray([])
+      return () => {}
+    }, [setSelectedInterests, setLabelArray])
+  )
 
   const handleRemoveInterest = (interest: string) => {
     setSelectedInterests(


### PR DESCRIPTION
# What I did
Solved a minor bug in Interests Screen. 

# How I did it
Using useCallback and useFocusEffect, every time the user leaves the InterestScreen, the arrays containing the interests and the labels reset 

# How to verify it
Go to interests screen, pick some interests, quit the screen and return to the screen once again. The list should be reset


# Pre-merge checklist
The changes I have introduced:
- [ ] work correctly
- [ ] do not break other functionalities
- [ ] work correctly on Android
- [ ] are fully tested