### PR TITLE
feat: display interests in profile

### DIFF
--- a/__test__/screens/Profile/ProfileInterests/ProfileInterests.test.tsx
+++ b/__test__/screens/Profile/ProfileInterests/ProfileInterests.test.tsx
@@ -1,12 +1,39 @@
-import React from 'react'
-import { render } from '@testing-library/react-native'
-import { ProfileInterests } from '../../../../screens/Profile/ProfileInterests/ProfileInterests'
+import React from "react"
+import { render } from "@testing-library/react-native"
+import { ProfileInterests } from "../../../../screens/Profile/ProfileInterests/ProfileInterests"
+import { User } from "../../../../types/User"
 
-describe('ProfileInterests', () => {
-  
-  it('renders correctly', () => {
-    const component = render(<ProfileInterests />)
-    expect(component).toBeTruthy()
+// Mock user data
+const mockUser: User = {
+  uid: "123",
+  firstName: "John",
+  lastName: "Doe",
+  location: "New York",
+  profilePicture: "https://example.com/profile.jpg",
+  description: "Test user description",
+  selectedInterests: ["Music", "Sports", "Art", "Travel"],
+  email: "",
+  friends: [],
+  events: [],
+  date: new Date(),
+}
+
+describe("ProfileInterests", () => {
+  it("renders the user's interests correctly", () => {
+    const { getByText } = render(<ProfileInterests user={mockUser} />)
+
+    // Check if the interests are displayed
+    expect(getByText("Music")).toBeTruthy()
+    expect(getByText("Sports")).toBeTruthy()
+    expect(getByText("Art")).toBeTruthy()
+    expect(getByText("Travel")).toBeTruthy()
   })
-  
+
+  it("renders the correct number of interests", () => {
+    const { getAllByText } = render(<ProfileInterests user={mockUser} />)
+
+    // Check if the number of interests matches
+    const interestElements = getAllByText(/Music|Sports|Art|Travel/)
+    expect(interestElements.length).toBe(mockUser.selectedInterests.length)
+  })
 })

--- a/screens/Profile/ExternalProfileScreen/ExternalProfileScreen.tsx
+++ b/screens/Profile/ExternalProfileScreen/ExternalProfileScreen.tsx
@@ -153,7 +153,9 @@ const ExternalProfileScreen = () => {
         <View style={styles.separatorLine} />
 
         {selectedTab === "Events" && <ProfileEvents />}
-        {selectedTab === "Interests" && <ProfileInterests />}
+        {selectedTab === "Interests" && (
+          <ProfileInterests user={externalUser} />
+        )}
         {selectedTab === "Network" && <ProfileNetwork />}
       </View>
     </View>

--- a/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
+++ b/screens/Profile/MyProfileScreen/MyProfileScreen.tsx
@@ -91,7 +91,7 @@ export const MyProfileScreen = ({ navigation }: MyProfileScreenProps) => {
         />
 
         {selectedTab === "Events" && <ProfileEvents />}
-        {selectedTab === "Interests" && <ProfileInterests />}
+        {selectedTab === "Interests" && <ProfileInterests user={user} />}
       </View>
     </View>
   )

--- a/screens/Profile/ProfileInterests/ProfileInterests.tsx
+++ b/screens/Profile/ProfileInterests/ProfileInterests.tsx
@@ -1,11 +1,29 @@
-import { View, Text } from "react-native"
-import { styles } from "./styles"
 import React from "react"
+import { View, Text, FlatList } from "react-native"
+import { User } from "../../../types/User"
+import styles from "./styles"
+import { globalStyles } from "../../../assets/global/globalStyles"
 
-export const ProfileInterests = () => {
+interface ProfileInterestsProps {
+  user: User
+}
+
+const Interest = ({ interest }: { interest: string }) => (
+  <View style={styles.interestButton}>
+    <Text style={[styles.interestText, globalStyles.text]}>{interest}</Text>
+  </View>
+)
+
+export const ProfileInterests = ({ user }: ProfileInterestsProps) => {
   return (
     <View style={styles.container}>
-      <Text>profile interests</Text>
+      <FlatList
+        data={user.selectedInterests}
+        keyExtractor={(item) => item}
+        renderItem={({ item }) => <Interest interest={item} />}
+        numColumns={2}
+        style={styles.interestsGrid}
+      />
     </View>
   )
 }

--- a/screens/Profile/ProfileInterests/styles.ts
+++ b/screens/Profile/ProfileInterests/styles.ts
@@ -1,9 +1,117 @@
 import { StyleSheet } from "react-native"
+import {
+  lightGray,
+  peach,
+  black,
+  lightPeach,
+  white,
+  shadowColor,
+} from "../../../assets/colors/colors"
+import { BUTTON_HEIGHT, BUTTON_RADIUS } from "../../../assets/global/constants"
 
-export const styles = StyleSheet.create({
-    container: {
-        alignItems: "center",
-        flex: 1,
-        justifyContent: "center",
-    }
+const styles = StyleSheet.create({
+  buttonSmall: {
+    alignItems: "center",
+    backgroundColor: lightPeach,
+    borderColor: peach,
+    borderRadius: BUTTON_RADIUS,
+    borderWidth: 2,
+    display: "flex",
+    elevation: 8,
+    height: 40,
+    justifyContent: "center",
+    marginHorizontal: 5,
+    shadowColor,
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4,
+    width: 90,
+  },
+
+  buttonSmallLeft: {
+    backgroundColor: peach,
+  },
+
+  buttonText: {
+    color: black,
+  },
+
+  buttonTextLeft: {
+    color: white,
+  },
+
+  container: {
+    backgroundColor: white,
+    flex: 1,
+    padding: 20,
+  },
+
+  footer: {
+    position: "absolute",
+    width: "100%",
+  },
+
+  footerButton: {
+    backgroundColor: white,
+    borderRadius: BUTTON_RADIUS,
+    paddingHorizontal: 30,
+    paddingVertical: 15,
+  },
+  footerButtonText: {
+    color: black,
+    textAlign: "center",
+  },
+
+  image: {
+    alignSelf: "center",
+    height: "10%",
+    marginRight: 10,
+    width: "15%",
+  },
+
+  input: {
+    alignSelf: "center",
+    borderColor: lightGray,
+    borderRadius: BUTTON_RADIUS,
+    borderWidth: 1,
+    height: BUTTON_HEIGHT,
+    marginBottom: 10,
+    paddingHorizontal: 30,
+    width: "95%",
+  },
+
+  interestButton: {
+    alignContent: "center",
+    borderColor: peach,
+    borderRadius: 10,
+    borderWidth: 2,
+    display: "flex",
+    height: 110,
+    justifyContent: "center",
+    marginBottom: 10,
+    marginHorizontal: 10,
+    padding: 10,
+    width: 150,
+  },
+
+  interestText: {
+    color: black,
+    left: 0,
+    right: 0,
+    textAlign: "center",
+  },
+
+  interestsGrid: {
+      alignSelf: "center",
+      paddingTop: 5,
+  },
+
+ 
+
+  
+
+  
+
+  
 })
+export default styles

--- a/screens/Profile/ProfileInterests/styles.ts
+++ b/screens/Profile/ProfileInterests/styles.ts
@@ -1,83 +1,11 @@
 import { StyleSheet } from "react-native"
-import {
-  lightGray,
-  peach,
-  black,
-  lightPeach,
-  white,
-  shadowColor,
-} from "../../../assets/colors/colors"
-import { BUTTON_HEIGHT, BUTTON_RADIUS } from "../../../assets/global/constants"
+import { peach, black, white } from "../../../assets/colors/colors"
 
 const styles = StyleSheet.create({
-  buttonSmall: {
-    alignItems: "center",
-    backgroundColor: lightPeach,
-    borderColor: peach,
-    borderRadius: BUTTON_RADIUS,
-    borderWidth: 2,
-    display: "flex",
-    elevation: 8,
-    height: 40,
-    justifyContent: "center",
-    marginHorizontal: 5,
-    shadowColor,
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.3,
-    shadowRadius: 4,
-    width: 90,
-  },
-
-  buttonSmallLeft: {
-    backgroundColor: peach,
-  },
-
-  buttonText: {
-    color: black,
-  },
-
-  buttonTextLeft: {
-    color: white,
-  },
-
   container: {
     backgroundColor: white,
     flex: 1,
     padding: 20,
-  },
-
-  footer: {
-    position: "absolute",
-    width: "100%",
-  },
-
-  footerButton: {
-    backgroundColor: white,
-    borderRadius: BUTTON_RADIUS,
-    paddingHorizontal: 30,
-    paddingVertical: 15,
-  },
-  footerButtonText: {
-    color: black,
-    textAlign: "center",
-  },
-
-  image: {
-    alignSelf: "center",
-    height: "10%",
-    marginRight: 10,
-    width: "15%",
-  },
-
-  input: {
-    alignSelf: "center",
-    borderColor: lightGray,
-    borderRadius: BUTTON_RADIUS,
-    borderWidth: 1,
-    height: BUTTON_HEIGHT,
-    marginBottom: 10,
-    paddingHorizontal: 30,
-    width: "95%",
   },
 
   interestButton: {
@@ -102,16 +30,8 @@ const styles = StyleSheet.create({
   },
 
   interestsGrid: {
-      alignSelf: "center",
-      paddingTop: 5,
+    alignSelf: "center",
+    paddingTop: 5,
   },
-
- 
-
-  
-
-  
-
-  
 })
 export default styles


### PR DESCRIPTION
# What I did
Implemented interest display in each user's profile

# How I did it
By modifying the ProfileInterests screen into having a function that fetches the interests directly from the user and displays them in their profile. There is no fetching from the database.

# How to verify it
Go to your profile and a friend profile and verify that the interests display correctly

# Demo Photo
First one is external profile, second one is MyProfile
<div style={"display: flex; flex-direction: row;"}>

  <img src=https://github.com/uniconnect-epfl/uniconnect/assets/91114548/e5ccdc1a-a57a-4759-9917-931d57cb0046 width=240>
  <img src = https://github.com/uniconnect-epfl/uniconnect/assets/91114548/5dfbc120-b02a-476a-8773-074058298205
  width=240>
</div>


# Pre-merge checklist
The changes I have introduced:
- [x] work correctly
- [x] do not break other functionalities
- [x] work correctly on Android
- [x] are fully tested