### PR TITLE
feat: added possibility to create an announcement

### DIFF
--- a/__test__/screens/EventCreation/EventCreationScreeen.test.tsx
+++ b/__test__/screens/EventCreation/EventCreationScreeen.test.tsx
@@ -178,25 +178,6 @@ describe("EventCreationScreen", () => {
     expect(titleInput.props.value).toBe("New Event Title")
   })
 
-  it("shows date input fiel when creating event", () => {
-    {
-      // restricting scope to avoid naming conflicts
-      const { queryByText } = render(
-        <SafeAreaProvider>
-          <EventCreationScreen isAnnouncement={true} navigation={mockNavigation} />
-        </SafeAreaProvider>
-      )
-      expect(queryByText("DD.MM.YYYY")).toBeNull()
-    }
-
-    const { queryByText } = render(
-      <SafeAreaProvider>
-        <EventCreationScreen isAnnouncement={false} navigation={mockNavigation} />
-      </SafeAreaProvider>
-    )
-    expect(queryByText("DD.MM.YYYY")).toBeTruthy()
-  })
-
   it('should handle "Add a description" button press', () => {
     const { getByText } = render(
       <SafeAreaProvider>

--- a/__test__/screens/EventCreation/EventCreationScreeen.test.tsx
+++ b/__test__/screens/EventCreation/EventCreationScreeen.test.tsx
@@ -37,8 +37,8 @@ jest.mock("firebase/firestore", () => {
   const originalModule = jest.requireActual("firebase/firestore")
 
   return {
-      ...originalModule,
-      getFirestore: jest.fn(() => ({} as Firestore)),
+    ...originalModule,
+    getFirestore: jest.fn(() => ({} as Firestore)),
   }
 })
 
@@ -73,7 +73,9 @@ jest.mock("react-native-safe-area-context", () => {
 
 describe("EventCreationScreen", () => {
   it("renders correctly", () => {
-    const { getByText } = render(<EventCreationScreen navigation={mockNavigation} />)
+    const { getByText } = render(
+      <EventCreationScreen navigation={mockNavigation} />
+    )
     expect(getByText("Validate")).toBeTruthy()
     expect(getByText("Add a description")).toBeTruthy()
     expect(getByText("Choose up to three tags")).toBeTruthy()
@@ -86,9 +88,9 @@ describe("EventCreationScreen", () => {
     const providerProps = {
       description: "",
       setDescription: mockSetDescription,
-      point: {x: 0, y: 0},
+      point: { x: 0, y: 0 },
       location: "test",
-      userId: "yep"
+      userId: "yep",
     }
     const { getByText } = render(
       <SafeAreaProvider>
@@ -109,7 +111,7 @@ describe("EventCreationScreen", () => {
     const providerProps = {
       description: "",
       setDescription: mockSetDescription,
-      point: {x: 0, y: 0},
+      point: { x: 0, y: 0 },
       location: "test",
       userId: "salue",
     }
@@ -117,7 +119,10 @@ describe("EventCreationScreen", () => {
       <SafeAreaProvider>
         {/* @ts-expect-error this is a test mock */}
         <RegistrationContext.Provider value={providerProps}>
-          <EventCreationScreen isAnnouncement={true} navigation={mockNavigation} />
+          <EventCreationScreen
+            isAnnouncement={true}
+            navigation={mockNavigation}
+          />
         </RegistrationContext.Provider>
       </SafeAreaProvider>
     )
@@ -132,9 +137,9 @@ describe("EventCreationScreen", () => {
     const providerProps = {
       description: "",
       setDescription: mockSetDescription,
-      point: {x: 0, y: 0},
+      point: { x: 0, y: 0 },
       location: "test",
-      userId: undefined
+      userId: undefined,
     }
     const { getByText } = render(
       <SafeAreaProvider>
@@ -157,7 +162,7 @@ describe("EventCreationScreen", () => {
       setDescription: mockSetDescription,
       point: undefined,
       location: "test",
-      user: null
+      user: null,
     }
     const { getByText } = render(
       <SafeAreaProvider>
@@ -172,7 +177,9 @@ describe("EventCreationScreen", () => {
   })
 
   it("updates title input correctly", () => {
-    const { getByPlaceholderText } = render(<EventCreationScreen navigation={mockNavigation} />)
+    const { getByPlaceholderText } = render(
+      <EventCreationScreen navigation={mockNavigation} />
+    )
     const titleInput = getByPlaceholderText("Chemistry x Python")
     fireEvent.changeText(titleInput, "New Event Title")
     expect(titleInput.props.value).toBe("New Event Title")
@@ -214,26 +221,34 @@ describe("EventCreationScreen", () => {
   })
 
   it("checks if the description button navigates correctly", () => {
-    const { getByText } = render(<EventCreationScreen navigation={mockNavigation} />)
+    const { getByText } = render(
+      <EventCreationScreen navigation={mockNavigation} />
+    )
     fireEvent.press(getByText("Add a description"))
     //expect(mockNavigation).toHaveBeenCalledWith("Description")
   })
 
   it("navigates back when the back button is pressed", () => {
-    const { getByTestId } = render(<EventCreationScreen navigation={mockNavigation} />)
+    const { getByTestId } = render(
+      <EventCreationScreen navigation={mockNavigation} />
+    )
     fireEvent.press(getByTestId("back-arrow"))
     //expect(mockGoBack).toHaveBeenCalled()
   })
 
   it("updates title input correctly", () => {
-    const { getByPlaceholderText } = render(<EventCreationScreen navigation={mockNavigation} />)
+    const { getByPlaceholderText } = render(
+      <EventCreationScreen navigation={mockNavigation} />
+    )
     const titleInput = getByPlaceholderText("Chemistry x Python")
     fireEvent.changeText(titleInput, "New Event Title")
     expect(titleInput.props.value).toBe("New Event Title")
   })
 
   it("handles interest tag selection", () => {
-    const { getByText } = render(<EventCreationScreen navigation={mockNavigation} />)
+    const { getByText } = render(
+      <EventCreationScreen navigation={mockNavigation} />
+    )
     fireEvent.press(getByText("Choose up to three tags"))
     // Assume modal or dropdown opens, simulate selecting a tag
     // Add mock function or state update check here
@@ -243,13 +258,16 @@ describe("EventCreationScreen", () => {
     const { queryByText, rerender } = render(
       <EventCreationScreen isAnnouncement={true} navigation={mockNavigation} />
     )
-    rerender(<EventCreationScreen isAnnouncement={false} navigation={mockNavigation} />)
+    rerender(
+      <EventCreationScreen isAnnouncement={false} navigation={mockNavigation} />
+    )
     expect(queryByText("Add a location")).toBeTruthy()
   })
 
   it("can add locations", () => {
-    const { getByText } = render(<EventCreationScreen navigation={mockNavigation} />)
+    const { getByText } = render(
+      <EventCreationScreen navigation={mockNavigation} />
+    )
     fireEvent.press(getByText("Add a location"))
   })
-
 })

--- a/__test__/screens/Explore/AnnouncementScreen.test.tsx
+++ b/__test__/screens/Explore/AnnouncementScreen.test.tsx
@@ -8,6 +8,17 @@ import { getAllAnnouncements } from "../../../firebase/ManageAnnouncements"
 
 // Mock any external components not relevant for the test
 
+const mockNavigate = jest.fn()
+
+jest.mock("@react-navigation/native", () => {
+  return {
+    ...jest.requireActual("@react-navigation/native"),
+    useNavigation: () => ({
+      navigate: mockNavigate,
+    }),
+  }
+})
+
 jest.mock("../../../firebase/firebaseConfig", () => ({
   db: jest.fn(() => ({} as Firestore)),
 }))

--- a/screens/EventCreation/EventCreationScreen.tsx
+++ b/screens/EventCreation/EventCreationScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from "react"
 import { View, Text, ScrollView, Pressable } from "react-native"
 import { styles } from "./styles"
-import { NavigationProp, ParamListBase } from "@react-navigation/native"
+import { NavigationProp, ParamListBase, useRoute } from "@react-navigation/native"
 import { Ionicons } from "@expo/vector-icons"
 import { globalStyles } from "../../assets/global/globalStyles"
 import { peach, white } from "../../assets/colors/colors"
@@ -20,10 +20,12 @@ import { BackArrow } from "../../components/BackArrow/BackArrow"
 
 interface EventCreationScreenProps {
   navigation: NavigationProp<ParamListBase>,
-  isAnnouncement?: boolean
 }
 
-const EventCreationScreen = ({ navigation, isAnnouncement }: EventCreationScreenProps) => {
+const EventCreationScreen = ({ navigation }: EventCreationScreenProps) => {
+  const route = useRoute()
+  const isAnnouncement = route.params?.isAnnouncement
+
   const [dateModal, setDateModal] = useState(false)
   const [date, setDate] = useState<Date>(new Date())
   const [hasBeenTouched, setHasBeenTouched] = useState(false)

--- a/screens/Explore/AnnouncementScreen/AnnouncementScreen.tsx
+++ b/screens/Explore/AnnouncementScreen/AnnouncementScreen.tsx
@@ -62,7 +62,7 @@ const AnnouncementScreen = ({ onAnnoucmentPress }: AnnouncementsScreenProps) => 
   return (
     <View style={styles.view}>
       <View style={styles.searchAndMap}>
-        <Pressable onPress={() => navigation.navigate("EventCreation" as never)} style={styles.createEventWrapper} >
+        <Pressable onPress={() => navigation.navigate("EventCreation" as never, {isAnnouncement: true})} style={styles.createEventWrapper} >
           <Text style={[globalStyles.smallText, styles.createEvent]}>Create an announcement</Text>
           <Ionicons name="create-outline" size={16} />
         </Pressable>

--- a/screens/Explore/AnnouncementScreen/AnnouncementScreen.tsx
+++ b/screens/Explore/AnnouncementScreen/AnnouncementScreen.tsx
@@ -1,11 +1,14 @@
 import React, { useEffect, useState } from 'react'
-import { View, Text, SectionList, SectionListRenderItemInfo, TouchableOpacity } from 'react-native'
+import { View, Text, SectionList, SectionListRenderItemInfo, TouchableOpacity, Pressable } from 'react-native'
 import { styles } from './styles'// Ensure the paths are correct
 import AnnouncementCard from '../../../components/AnnoucementCard/AnnouncementCard'
 import { Announcement } from '../../../types/Annoucement'
 import { getAllAnnouncements } from '../../../firebase/ManageAnnouncements'
 import { showErrorToast } from '../../../components/ToastMessage/toast'
 import LoadingScreen from '../../Loading/LoadingScreen'
+import { globalStyles } from '../../../assets/global/globalStyles'
+import { Ionicons } from '@expo/vector-icons'
+import { useNavigation } from '@react-navigation/native'
 
 interface AnnouncementsScreenProps {
   onAnnoucmentPress: (announcement: Announcement) => void
@@ -14,6 +17,7 @@ interface AnnouncementsScreenProps {
 const AnnouncementScreen = ({ onAnnoucmentPress }: AnnouncementsScreenProps) => {
 
   //const [searchQuery, setSearchQuery] = useState("")
+  const navigation = useNavigation()
   const [isLoading, setIsLoading] = useState(true)
   const [announcements, setAnnouncements] = useState<Announcement[] | null>(null)
 
@@ -58,6 +62,10 @@ const AnnouncementScreen = ({ onAnnoucmentPress }: AnnouncementsScreenProps) => 
   return (
     <View style={styles.view}>
       <View style={styles.searchAndMap}>
+        <Pressable onPress={() => navigation.navigate("EventCreation" as never)} style={styles.createEventWrapper} >
+          <Text style={[globalStyles.smallText, styles.createEvent]}>Create an announcement</Text>
+          <Ionicons name="create-outline" size={16} />
+        </Pressable>
         {/* <TextInput
           style={styles.input}
           placeholder="Search..."

--- a/screens/Explore/AnnouncementScreen/styles.ts
+++ b/screens/Explore/AnnouncementScreen/styles.ts
@@ -1,5 +1,6 @@
 import { StyleSheet } from "react-native"
 import {
+  black,
   lightGray,
   peach,
   white
@@ -17,6 +18,10 @@ export const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
+  },
+  createEvent: {color: black},
+  createEventWrapper: {
+    justifyContent: "center"
   },
   input: {
     borderColor: lightGray,


### PR DESCRIPTION
# What I did
Added a button which leads to a page to create new announcements directly in the app.

# How I did it
Replaced props with params and connected navigation from `AnnouncementScreen` -> `EventCreationScreen` with the `isAnnouncement` param enabled. 

# How to verify it
1. Go to the announcement screen
2. Press the button to create a new announcement
3. Successfully create an announcement.

# Demo video
https://github.com/uniconnect-epfl/uniconnect/assets/11707683/65892157-0bb7-4002-8a3d-830f0487a3c1


# Pre-merge checklist
The changes I have introduced:
- [x] work correctly
- [x] do not break other functionalities
- [x] work correctly on Android
- [x] are fully tested