### PR TITLE
fix: solve layout and announcement problems

### DIFF
--- a/__test__/screens/EventCreation/EventCreationScreeen.test.tsx
+++ b/__test__/screens/EventCreation/EventCreationScreeen.test.tsx
@@ -24,6 +24,7 @@ const mockNavigation = {
   canGoBack: jest.fn(),
   dangerouslyGetParent: jest.fn(),
   dangerouslyGetState: jest.fn(),
+  selectedInterests: jest.fn(),
 } as unknown as NavigationProp<ParamListBase>
 
 jest.mock("firebase/auth", () => ({
@@ -41,6 +42,18 @@ jest.mock("firebase/firestore", () => {
     getFirestore: jest.fn(() => ({} as Firestore)),
   }
 })
+
+//added after interests rendering 
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useContext: () => ({
+    selectedInterests: jest.fn(),
+    description: jest.fn(),
+    setDescription: jest.fn(),
+    setSelectedInterests: jest.fn(),
+  }),
+}))
+
 
 jest.mock("@react-navigation/native", () => {
   return {

--- a/__test__/screens/Explore/EventScreen.test.tsx
+++ b/__test__/screens/Explore/EventScreen.test.tsx
@@ -1,10 +1,11 @@
 
-import { render } from '@testing-library/react-native'
+import { render, waitFor } from '@testing-library/react-native'
 import EventScreen from '../../../screens/Explore/EventScreen/EventScreen'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import React from 'react'
 import { Firestore } from 'firebase/firestore'
 import { NavigationContainer, NavigationProp, ParamListBase } from '@react-navigation/native'
+import { showErrorToast } from '../../../components/ToastMessage/toast'
 
 
 jest.mock("../../../firebase/firebaseConfig", () => ({
@@ -62,14 +63,47 @@ describe('EventScreen', () => {
 
   it('refresh', async () => {
 
-    const { debug } = render(
+    const { getByText } = render(
       <NavigationContainer>
         <SafeAreaProvider>
           <EventScreen onEventPress={() => { }} userID='123' />
         </SafeAreaProvider>
       </NavigationContainer>
     )
-    debug()
+    await waitFor (()  => {
+    expect(getByText('Upcoming Events')).toBeTruthy()
+    })
+  })
+
+})
+
+///Test for no events
+
+jest.mock('../../../firebase/ManageEvents', () => ({
+  getAllFutureEvents: jest.fn(() => Promise.resolve([
+  ])),
+  getAllPastEvents: jest.fn(() => Promise.resolve([
+  ]))
+}))
+jest.mock("../../../components/ToastMessage/toast", () => ({
+  showErrorToast: jest.fn(),
+  showSuccessToast: jest.fn(),
+}))
+
+describe('EventScreenNoEvents', () => {
+
+  it('refresh', async () => {
+
+     render(
+      <NavigationContainer>
+        <SafeAreaProvider>
+          <EventScreen onEventPress={() => { }} userID='123' />
+        </SafeAreaProvider>
+      </NavigationContainer>
+    )
+    await waitFor (() => {
+    expect(showErrorToast).toHaveBeenCalledWith("Error fetching user data. Please check your connection and try again.")
+    })
   })
 
 })

--- a/__test__/screens/Explore/EventScreen.test.tsx
+++ b/__test__/screens/Explore/EventScreen.test.tsx
@@ -48,6 +48,35 @@ jest.mock('@react-navigation/native', () => {
   }
 })
 
+export type User = {
+  uid: string
+  email: string
+  firstName: string
+  friends: string[]
+  lastName: string
+  date: Date
+  description: string
+  location: string
+  selectedInterests: string[]
+  profilePicture: string
+  events: string[]
+}
+jest.mock('../../../firebase/User.ts', () => ({
+  getUserData: jest.fn(() => Promise.resolve({
+    uid: "1234",
+    email: "test",
+    firstName: "alex",
+    lastName: "doe",
+    friends: [],
+    date: new Date(),
+    description: "test description",
+    location: "test location",
+    selectedInterests: [],
+    profilePicture: "test.jpg",
+    events: []
+  }))
+}))
+
 jest.mock('../../../firebase/ManageEvents', () => ({
   getAllFutureEvents: jest.fn(() => Promise.resolve([
     { id: '1', title: 'Future Event 1', date: '2024-01-01' },
@@ -59,6 +88,8 @@ jest.mock('../../../firebase/ManageEvents', () => ({
     { id: '4', title: 'Past Event 2', date: '2022-01-02' }
   ]))
 }))
+
+
 
 describe('EventScreen', () => {
 
@@ -104,7 +135,7 @@ describe('EventScreenNoEvents', () => {
       </NavigationContainer>
     )
     await waitFor (() => {
-    expect(showErrorToast).toHaveBeenCalledWith("Error fetching user data. Please check your connection and try again.")
+    expect(showErrorToast).toHaveBeenCalledWith("You have no events yet.")
     })
   })
 

--- a/__test__/screens/Explore/EventScreen.test.tsx
+++ b/__test__/screens/Explore/EventScreen.test.tsx
@@ -1,7 +1,6 @@
 
-import { render, waitFor } from '@testing-library/react-native'
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import EventScreen from '../../../screens/Explore/EventScreen/EventScreen'
-import { SafeAreaProvider } from 'react-native-safe-area-context'
 import React from 'react'
 import { Firestore } from 'firebase/firestore'
 import { NavigationContainer, NavigationProp, ParamListBase } from '@react-navigation/native'
@@ -43,7 +42,9 @@ const mockNavigation = {
 jest.mock('@react-navigation/native', () => {
   return {
     ...jest.requireActual('@react-navigation/native'), // keep all the original implementations
-    useNavigation: () => mockNavigation,
+    useNavigation: () => ({
+      navigate: mockNavigation.navigate,
+    }),
   }
 })
 
@@ -65,13 +66,14 @@ describe('EventScreen', () => {
 
     const { getByText } = render(
       <NavigationContainer>
-        <SafeAreaProvider>
+        
           <EventScreen onEventPress={() => { }} userID='123' />
-        </SafeAreaProvider>
+        
       </NavigationContainer>
     )
     await waitFor (()  => {
     expect(getByText('Upcoming Events')).toBeTruthy()
+    
     })
   })
 
@@ -92,18 +94,33 @@ jest.mock("../../../components/ToastMessage/toast", () => ({
 
 describe('EventScreenNoEvents', () => {
 
-  it('refresh', async () => {
+  it('check Errors', async () => {
 
      render(
       <NavigationContainer>
-        <SafeAreaProvider>
+        
           <EventScreen onEventPress={() => { }} userID='123' />
-        </SafeAreaProvider>
+        
       </NavigationContainer>
     )
     await waitFor (() => {
     expect(showErrorToast).toHaveBeenCalledWith("Error fetching user data. Please check your connection and try again.")
     })
   })
+
+  it('check Errors', async () => {
+
+    const {getByText}= render(
+     <NavigationContainer>
+       
+         <EventScreen onEventPress={() => { }} userID='123' />
+       
+     </NavigationContainer>
+   )
+   await waitFor (() => {
+   fireEvent.press(getByText('Create an event'))
+   expect(mockNavigation.navigate).toHaveBeenCalled
+ })
+})
 
 })

--- a/__test__/screens/Registration/InterestsScreen/InterestsScreen.test.tsx
+++ b/__test__/screens/Registration/InterestsScreen/InterestsScreen.test.tsx
@@ -43,8 +43,8 @@ const mockNavigation = {
   isFocused: jest.fn().mockReturnValue(false),
 }
 
-jest.mock('@react-navigation/native', () => {
-  const actualNav = jest.requireActual('@react-navigation/native')
+jest.mock("@react-navigation/native", () => {
+  const actualNav = jest.requireActual("@react-navigation/native")
   return {
     ...actualNav,
     useNavigation: () => mockNavigation,
@@ -73,7 +73,7 @@ describe("InterestsScreen", () => {
       )
 
       await waitFor(() => {
-        expect(getByPlaceholderText("Search")).toBeTruthy()
+        expect(getByPlaceholderText("Search...")).toBeTruthy()
         const interestButtons = getAllByText(/.+/)
         expect(interestButtons.length).toBeGreaterThan(0)
       })

--- a/components/AnnoucementCard/AnnouncementCard.tsx
+++ b/components/AnnoucementCard/AnnouncementCard.tsx
@@ -18,7 +18,7 @@ const AnnouncementCard = ({announcement, recommended} : AnnouncementCardProps) =
         {announcement.interests.join("- ")}
       </Text>
 
-      {!recommended && (
+      {recommended && (
         <Text style={styles.recommended}>Matches all your interests ★</Text>
       )}
     </View>

--- a/firebase/Registration.ts
+++ b/firebase/Registration.ts
@@ -47,7 +47,8 @@ export async function storeInitialUserData(uid: string, email: string, firstName
       location: location,
       description: description,
       selectedInterests: selectedInterests,
-      profilePicture: ""
+      profilePicture: "",
+      events : []
     })
   } catch (error) {
     showErrorToast("There was an error storing your user data, please try again.")

--- a/screens/EventCreation/EventCreationScreen.tsx
+++ b/screens/EventCreation/EventCreationScreen.tsx
@@ -155,15 +155,15 @@ const EventCreationScreen = ({ navigation }: EventCreationScreenProps) => {
               </View>
               {selectedInterests?.length !== 0 && (
                 <>
+                 <View style={styles.interestsContainer}>
                   <Text style={[styles.tagsTitle, globalStyles.text]}>
                     Interests selected!
                   </Text>
-                  {selectedInterests.map((interest, index) => (
-                    <Text key={index} style={globalStyles.text}>
-                      {interest}
+                    <Text style={[styles.interests, globalStyles.text]}>
+                      {selectedInterests.join(" - ")}
                     </Text>
-                  ))}
-                </>
+                  </View>
+                  </>
               )}
             </View>
           </Pressable>

--- a/screens/EventCreation/EventCreationScreen.tsx
+++ b/screens/EventCreation/EventCreationScreen.tsx
@@ -154,9 +154,16 @@ const EventCreationScreen = ({ navigation }: EventCreationScreenProps) => {
                 )}
               </View>
               {selectedInterests?.length !== 0 && (
-                <Text style={[styles.tagsTitle, globalStyles.text]}>
-                  Interests selected!
-                </Text>
+                <>
+                  <Text style={[styles.tagsTitle, globalStyles.text]}>
+                    Interests selected!
+                  </Text>
+                  {selectedInterests.map((interest, index) => (
+                    <Text key={index} style={globalStyles.text}>
+                      {interest}
+                    </Text>
+                  ))}
+                </>
               )}
             </View>
           </Pressable>

--- a/screens/EventCreation/styles.ts
+++ b/screens/EventCreation/styles.ts
@@ -80,6 +80,17 @@ export const styles = StyleSheet.create({
     paddingHorizontal: 30,
     width: "100%",
   },
+  interests: {
+    color: black,
+    fontSize: 12,
+    fontStyle: "italic",
+    marginLeft: 13,
+    paddingBottom: 5,
+  },
+
+  interestsContainer: {
+    flexDirection: "column",
+  },
   label: {
     color: black,
     display: "flex",
@@ -91,7 +102,6 @@ export const styles = StyleSheet.create({
   mandatoryInput: {
     flexDirection: "row",
   },
-
   section: {
     display: "flex",
     flexDirection: "column",
@@ -101,11 +111,13 @@ export const styles = StyleSheet.create({
     paddingTop: 10,
     width: "100%",
   },
+
   tags: {
     flexDirection: "row",
     justifyContent: "space-between",
     marginBottom: 10,
   },
+
   tagsSeparator: {
     borderBottomColor: black,
     borderBottomWidth: 1,
@@ -114,6 +126,6 @@ export const styles = StyleSheet.create({
   tagsTitle: {
     color: black,
     marginBottom: 10,
-    padding: 10,
+    paddingTop: 7,
   },
 })

--- a/screens/Explore/AnnouncementScreen/AnnouncementScreen.tsx
+++ b/screens/Explore/AnnouncementScreen/AnnouncementScreen.tsx
@@ -95,7 +95,6 @@ const AnnouncementScreen = ({
         recommendAnnouncements(searchedAnnouncement)
       setFilteredAnnouncements(recommendedAnnouncements)
     } else {
-      console.log(userData?.selectedInterests)
 
       setFilteredAnnouncements(recommendAnnouncements(announcements))
     }

--- a/screens/Explore/AnnouncementScreen/AnnouncementScreen.tsx
+++ b/screens/Explore/AnnouncementScreen/AnnouncementScreen.tsx
@@ -156,17 +156,18 @@ const AnnouncementScreen = ({
   return (
     <View style={styles.view}>
       <View style={styles.searchAndMap}>
-        <Pressable onPress={() => navigation.navigate("EventCreation" as never, {isAnnouncement: true})} style={styles.createEventWrapper} >
-          <Text style={[globalStyles.smallText, styles.createEvent]}>Create an announcement</Text>
-          <Ionicons name="create-outline" size={16} />
-        </Pressable>
          <TextInput
           style={styles.input}
           placeholder="Search..."
           value={searchQuery}
           onChangeText={handleSearch}
         />
+        <Pressable onPress={() => navigation.navigate("EventCreation" as never, {isAnnouncement: true})} style={styles.createEventWrapper} >
+          <Text style={[globalStyles.smallText, styles.createEvent]}>Create an announcement</Text>
+          <Ionicons name="create-outline" size={16} />
+        </Pressable>
       </View>
+      
       <View style={styles.container}>
         <SectionList
           sections={sections}

--- a/screens/Explore/AnnouncementScreen/AnnouncementScreen.tsx
+++ b/screens/Explore/AnnouncementScreen/AnnouncementScreen.tsx
@@ -6,7 +6,7 @@ import {
   SectionListRenderItemInfo,
   TouchableOpacity,
   Pressable,
-  TextInput,
+  
 } from "react-native"
 import { styles } from "./styles" // Ensure the paths are correct
 import AnnouncementCard from "../../../components/AnnoucementCard/AnnouncementCard"
@@ -20,6 +20,7 @@ import { getUserData } from "../../../firebase/User"
 import { globalStyles } from "../../../assets/global/globalStyles"
 import { Ionicons } from "@expo/vector-icons"
 import { useNavigation } from "@react-navigation/native"
+import InputField from "../../../components/InputField/InputField"
 
 interface AnnouncementsScreenProps {
   onAnnouncementPress: (announcement: Announcement) => void
@@ -110,7 +111,7 @@ const AnnouncementScreen = ({
       }))
     }
 
-    const recomm =  announcements
+    const recomm = announcements
       .map((announcement) => ({
         announcement,
         recommended:
@@ -123,8 +124,8 @@ const AnnouncementScreen = ({
         if (a.recommended && !b.recommended) return -1
         return 0
       })
-      console.log(recomm)
-      return recomm
+    console.log(recomm)
+    return recomm
   }
 
   const sections = [
@@ -163,18 +164,26 @@ const AnnouncementScreen = ({
   return (
     <View style={styles.view}>
       <View style={styles.searchAndMap}>
-         <TextInput
-          style={styles.input}
+        <InputField
           placeholder="Search..."
           value={searchQuery}
           onChangeText={handleSearch}
         />
-        <Pressable onPress={() => navigation.navigate("EventCreation" as never, {isAnnouncement: true})} style={styles.createEventWrapper} >
-          <Text style={[globalStyles.smallText, styles.createEvent]}>Create an announcement</Text>
+        <Pressable
+          onPress={() =>
+            navigation.navigate("EventCreation" as never, {
+              isAnnouncement: true,
+            })
+          }
+          style={styles.createEventWrapper}
+        >
+          <Text style={[globalStyles.smallText, styles.createEvent]}>
+            Create an announcement
+          </Text>
           <Ionicons name="create-outline" size={16} />
         </Pressable>
       </View>
-      
+
       <View style={styles.container}>
         <SectionList
           sections={sections}

--- a/screens/Explore/AnnouncementScreen/AnnouncementScreen.tsx
+++ b/screens/Explore/AnnouncementScreen/AnnouncementScreen.tsx
@@ -20,7 +20,6 @@ import { getUserData } from "../../../firebase/User"
 import { globalStyles } from "../../../assets/global/globalStyles"
 import { Ionicons } from "@expo/vector-icons"
 import { useNavigation } from "@react-navigation/native"
-import InputField from "../../../components/InputField/InputField"
 
 interface AnnouncementsScreenProps {
   onAnnouncementPress: (announcement: Announcement) => void

--- a/screens/Explore/AnnouncementScreen/AnnouncementScreen.tsx
+++ b/screens/Explore/AnnouncementScreen/AnnouncementScreen.tsx
@@ -124,7 +124,6 @@ const AnnouncementScreen = ({
         if (a.recommended && !b.recommended) return -1
         return 0
       })
-    console.log(recomm)
     return recomm
   }
 

--- a/screens/Explore/AnnouncementScreen/AnnouncementScreen.tsx
+++ b/screens/Explore/AnnouncementScreen/AnnouncementScreen.tsx
@@ -109,7 +109,7 @@ const AnnouncementScreen = ({
       }))
     }
 
-    return announcements
+    const recomm =  announcements
       .map((announcement) => ({
         announcement,
         recommended: announcement.interests.filter((interest) =>
@@ -121,6 +121,8 @@ const AnnouncementScreen = ({
         if (a.recommended && !b.recommended) return -1
         return 0
       })
+      console.log(recomm)
+      return recomm
   }
 
   const sections = [

--- a/screens/Explore/AnnouncementScreen/styles.ts
+++ b/screens/Explore/AnnouncementScreen/styles.ts
@@ -19,9 +19,14 @@ export const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  createEvent: {color: black},
+  createEvent: {color: black,
+   
+  },
   createEventWrapper: {
-    justifyContent: "center"
+    alignItems: "center",
+    flexDirection: "row",
+    justifyContent: "center",
+
   },
   input: {
     borderColor: lightGray,
@@ -30,7 +35,7 @@ export const styles = StyleSheet.create({
     fontFamily: "JetBrainsMono_400Regular",
     height: 40,
     paddingHorizontal: 20,
-    width: "100%",
+    width: "57%",
   },
   searchAndMap: {
     alignItems: "center",

--- a/screens/Explore/AnnouncementScreen/styles.ts
+++ b/screens/Explore/AnnouncementScreen/styles.ts
@@ -18,10 +18,7 @@ export const styles = StyleSheet.create({
    
   },
   createEventWrapper: {
-    alignItems: "center",
-    flexDirection: "row",
-    justifyContent: "center",
-
+    justifyContent: "center"
   },
   input: {
     borderColor: lightGray,
@@ -32,6 +29,7 @@ export const styles = StyleSheet.create({
     paddingHorizontal: 20,
     width: "57%",
   },
+  
   searchAndMap: {
     alignItems: "center",
     flexDirection: "row",
@@ -47,5 +45,5 @@ export const styles = StyleSheet.create({
   },
   view: {
     flex: 1,
-  },
+  }
 })

--- a/screens/Explore/EventScreen/EventScreen.tsx
+++ b/screens/Explore/EventScreen/EventScreen.tsx
@@ -78,6 +78,9 @@ const EventScreen = ({ onEventPress, userID }: EventsScreenProps) => {
 
             setFilteredFutureEvents(userFutureEvents)
             setFilteredPastEvents(userPastEvents)
+            if (userFutureEvents.length === 0 && userPastEvents.length === 0) {
+              showErrorToast("You have no events yet.")
+            }
           }
           const userImages = await fetchAllUserImages()
           if(userImages) {
@@ -92,6 +95,9 @@ const EventScreen = ({ onEventPress, userID }: EventsScreenProps) => {
 
           setFilteredFutureEvents(fetchedFutureEvents)
           setFilteredPastEvents(fetchedPastEvents)
+          if (fetchedFutureEvents.length === 0 && fetchedPastEvents.length === 0) {
+            showErrorToast("You have no events yet.")
+          }
           const userImages = await fetchAllUserImages()
           if(userImages) {
             setUserImages(userImages)

--- a/screens/Explore/EventScreen/EventScreen.tsx
+++ b/screens/Explore/EventScreen/EventScreen.tsx
@@ -220,7 +220,7 @@ const EventScreen = ({ onEventPress, userID }: EventsScreenProps) => {
           renderItem={renderItem}
           renderSectionHeader={renderSectionHeader}
           showsVerticalScrollIndicator={false}
-          stickySectionHeadersEnabled={false}
+          stickySectionHeadersEnabled={true}
         />
       </View>
     </View>

--- a/screens/Registration/InterestsScreen/InterestsScreen.tsx
+++ b/screens/Registration/InterestsScreen/InterestsScreen.tsx
@@ -49,7 +49,7 @@ const InterestButton: React.FC<InterestButtonProps> = ({
     </Text>
   </TouchableOpacity>
 )
-
+//add announcement
 const InterestsScreen = () => {
   const insets = useSafeAreaInsets()
   const [searchTerm, setSearchTerm] = useState("")


### PR DESCRIPTION
# What I did
The app notifies the user when he has no events yet. 
I added the sticky headers for the events screen so we know if we are seeing upcoming events or past ones.
We can now see the selected interests when we create an announcement

# How I did it
I added an empty array for events in the creation method, so the query in the database is not throwing an error but retrieve an empty array. It's detected and a different message than "Error with your connection is shown". 

# How to verify it
You can check the event screen to see the sticky header. 
You can try to go to the event screen without any events to see the correct notification "No events yet"
When selecting the interests for an announcement, you can now see what you selected.
# Demo video
<img width="377" alt="image" src="https://github.com/uniconnect-epfl/uniconnect/assets/108724823/2ad1497e-f3b2-4d4c-8740-9ff0165b9d46">
<img width="387" alt="image" src="https://github.com/uniconnect-epfl/uniconnect/assets/108724823/c0edcda3-1c61-461c-a26d-d1b58af385f9">
<img width="381" alt="image" src="https://github.com/uniconnect-epfl/uniconnect/assets/108724823/f09d1c7e-964e-4e41-a7e7-865a74f71e1d">


# Pre-merge checklist
The changes I have introduced:
- [x] work correctly
- [x] do not break other functionalities
- [x] work correctly on Android
- [x] are fully tested